### PR TITLE
Refine UI spacing and fix Supabase server cookie usage

### DIFF
--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -21,12 +21,43 @@ export default async function AdminDashboard() {
   }
 
   return (
-    <div className="p-6">
-      <h1 className="text-3xl font-bold mb-4">Haiti City Portal Dashboard</h1>
-      <p>Welcome, {profile?.full_name || user.email}</p>
-      <p className="text-sm opacity-70">
-        Role: {profile?.role} · Municipality: {profile?.municipality_code || "—"}
-      </p>
+    <div className="mx-auto w-full max-w-5xl px-4 pb-24 pt-16 sm:px-6 lg:max-w-6xl lg:px-8">
+      <div className="rounded-3xl border border-white/10 bg-white/5 p-8 shadow-xl shadow-black/20 backdrop-blur">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-3xl font-semibold text-white">Haiti City Portal dashboard</h1>
+            <p className="mt-1 text-sm text-slate-300">
+              Manage municipal data, approve issues, and coordinate with city partners.
+            </p>
+          </div>
+          <span className="inline-flex items-center gap-2 self-start rounded-full bg-cyan-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-cyan-200">
+            Admin access
+          </span>
+        </div>
+        <dl className="mt-8 grid gap-6 sm:grid-cols-2">
+          <div className="rounded-2xl border border-white/10 bg-slate-950/40 p-5 text-sm text-slate-200">
+            <dt className="text-xs font-semibold uppercase tracking-wide text-slate-400">Signed in as</dt>
+            <dd className="mt-1 text-lg font-semibold text-white">
+              {profile?.full_name || user.email}
+            </dd>
+            <dd className="mt-2 text-xs text-slate-400">{user.email}</dd>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-slate-950/40 p-5 text-sm text-slate-200">
+            <dt className="text-xs font-semibold uppercase tracking-wide text-slate-400">Permissions</dt>
+            <dd className="mt-1 flex flex-wrap items-center gap-2 text-white">
+              <span className="inline-flex items-center gap-1 rounded-full border border-cyan-400/40 bg-cyan-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-cyan-100">
+                {profile?.role ?? "Viewer"}
+              </span>
+              <span className="inline-flex items-center gap-1 rounded-full border border-orange-400/30 bg-orange-400/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-orange-200">
+                Municipality {profile?.municipality_code || "—"}
+              </span>
+            </dd>
+            <dd className="mt-2 text-xs text-slate-400">
+              Contact digital services to adjust permissions or switch municipalities.
+            </dd>
+          </div>
+        </dl>
+      </div>
     </div>
   );
 }

--- a/src/app/(public)/data/page.tsx
+++ b/src/app/(public)/data/page.tsx
@@ -76,7 +76,7 @@ export default async function DataGalleryPage() {
   const items = datasets.length > 0 ? datasets : enableLocalMode ? localFallback : [];
 
   return (
-    <div className="mx-auto w-full max-w-6xl px-4 py-20 sm:px-6">
+    <div className="mx-auto w-full max-w-6xl px-4 pb-24 pt-16 sm:px-6 lg:px-8">
       <div className="mb-12 flex flex-col gap-6 rounded-3xl border border-cyan-400/30 bg-white/5 p-8 shadow-xl shadow-cyan-400/20 backdrop-blur sm:flex-row sm:items-center sm:justify-between">
         <div className="space-y-3">
           <h1 className="text-3xl font-semibold text-white">Open data catalog</h1>
@@ -100,7 +100,7 @@ export default async function DataGalleryPage() {
         </div>
         <a
           href="mailto:data@haiticity.org"
-          className="inline-flex items-center justify-center gap-2 rounded-full border border-white/15 bg-white/5 px-5 py-2 text-sm font-semibold text-slate-100 transition hover:border-cyan-300 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
+          className="inline-flex items-center justify-center gap-2 self-start rounded-full border border-white/15 bg-white/5 px-5 py-2 text-sm font-semibold text-slate-100 transition hover:border-cyan-300 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
         >
           Request a dataset
           <svg

--- a/src/app/(public)/events/page.tsx
+++ b/src/app/(public)/events/page.tsx
@@ -88,8 +88,8 @@ export default async function EventsPage() {
   const monthKeys = Object.keys(grouped);
 
   return (
-    <div className="mx-auto w-full max-w-6xl px-4 py-20 sm:px-6">
-      <div className="mb-10 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+    <div className="mx-auto w-full max-w-6xl px-4 pb-24 pt-16 sm:px-6 lg:px-8">
+      <div className="mb-12 flex flex-col gap-6 rounded-3xl border border-white/10 bg-white/5 p-8 shadow-xl shadow-black/20 backdrop-blur sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-3xl font-semibold text-white">Community events</h1>
           <p className="mt-2 text-sm text-slate-300">
@@ -98,7 +98,7 @@ export default async function EventsPage() {
         </div>
         <Link
           href="/api/events/ics"
-          className="inline-flex items-center justify-center gap-2 rounded-full border border-cyan-400/50 bg-cyan-500/10 px-6 py-2.5 text-sm font-semibold text-cyan-200 transition hover:border-cyan-300 hover:bg-cyan-500/20 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
+          className="inline-flex items-center justify-center gap-2 self-start rounded-full border border-cyan-400/50 bg-cyan-500/10 px-6 py-2.5 text-sm font-semibold text-cyan-200 transition hover:border-cyan-300 hover:bg-cyan-500/20 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
         >
           Download calendar (.ics)
           <svg

--- a/src/app/(public)/issues/page.tsx
+++ b/src/app/(public)/issues/page.tsx
@@ -52,17 +52,21 @@ export default async function IssuesListPage() {
   const issues = (data && data.length > 0 ? data : fallbackIssues) ?? [];
 
   return (
-    <div className="mx-auto w-full max-w-5xl px-4 py-20 sm:px-6">
-      <div className="mb-10 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h1 className="text-3xl font-semibold text-white">Issues</h1>
-          <p className="mt-2 text-sm text-slate-300">
-            Recent reports from residents across the municipality. Public read access is enabled.
+    <div className="mx-auto w-full max-w-5xl px-4 pb-24 pt-16 sm:px-6 lg:max-w-6xl lg:px-8">
+      <div className="mb-12 flex flex-col gap-6 rounded-3xl border border-white/10 bg-white/5 p-8 shadow-xl shadow-black/20 backdrop-blur sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-3">
+          <h1 className="text-3xl font-semibold text-white">Service issues</h1>
+          <p className="text-sm text-slate-300">
+            Track recent reports from residents across the municipality. Status updates are refreshed in real time.
           </p>
+          <div className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-300">
+            <span className="flex h-2 w-2 rounded-full bg-cyan-400" aria-hidden />
+            Updated hourly from the civic response queue
+          </div>
         </div>
         <Link
           href="/issues/new"
-          className="inline-flex items-center justify-center gap-2 rounded-full bg-gradient-to-r from-cyan-400 to-sky-500 px-6 py-2.5 text-sm font-semibold text-slate-950 shadow-lg shadow-sky-500/30 transition hover:scale-[1.015] focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
+          className="inline-flex items-center justify-center gap-2 self-start rounded-full bg-gradient-to-r from-cyan-400 to-sky-500 px-6 py-2.5 text-sm font-semibold text-slate-950 shadow-lg shadow-sky-500/30 transition hover:scale-[1.015] focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
         >
           Report an issue
           <svg
@@ -113,8 +117,8 @@ export default async function IssuesListPage() {
         </div>
       ) : (
         <div className="relative">
-          <div className="absolute left-4 top-0 hidden h-full w-px bg-gradient-to-b from-cyan-400/60 via-white/20 to-transparent sm:block" aria-hidden />
-          <ul className="space-y-6">
+          <div className="absolute left-6 top-0 hidden h-full w-px bg-gradient-to-b from-cyan-400/60 via-white/20 to-transparent sm:block" aria-hidden />
+          <ul className="space-y-6 pl-0 sm:pl-6">
             {issues.map((issue) => {
               const statusLabel = formatStatus(issue.status);
               const tone = statusTone[statusLabel as keyof typeof statusTone] ?? statusTone.Pending;
@@ -123,7 +127,7 @@ export default async function IssuesListPage() {
                   key={issue.id}
                   className="group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-black/20 backdrop-blur transition hover:-translate-y-1 hover:border-cyan-400/40 hover:shadow-cyan-400/20"
                 >
-                  <span className="absolute -left-1 top-6 hidden h-5 w-5 rounded-full border-4 border-slate-950 bg-cyan-300 shadow-md sm:block" aria-hidden />
+                  <span className="absolute -left-[22px] top-6 hidden h-5 w-5 rounded-full border-4 border-slate-950 bg-cyan-300 shadow-md sm:block" aria-hidden />
                   <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
                     <div>
                       <h2 className="text-lg font-semibold text-white">{issue.title}</h2>

--- a/src/app/api/issues.geojson/route.ts
+++ b/src/app/api/issues.geojson/route.ts
@@ -1,4 +1,4 @@
-import { createServerSupabase } from "@/lib/supabase/server";
+import { createServerSupabaseWithAccess } from "@/lib/supabase/server";
 
 type IssuePoint = {
   id: string;
@@ -9,7 +9,7 @@ type IssuePoint = {
 };
 
 export async function GET() {
-  const supabase = await createServerSupabase();
+  const supabase = await createServerSupabaseWithAccess();
   const { data, error } = await supabase
     .from("issues")
     .select("id,title,latitude,longitude,created_at")

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -3,12 +3,12 @@ import LocaleSwitcher from "@/components/nav/LocaleSwitcher";
 
 const footerLinks = {
   About: [
-    { href: "/about", label: "About the Portal" },
+    { href: "/about", label: "About the portal" },
     { href: "/contact", label: "Contact" },
   ],
   "Open Data": [
-    { href: "/data", label: "Data Catalog" },
-    { href: "/api/events/ics", label: "Events Calendar (.ics)" },
+    { href: "/data", label: "Data catalog" },
+    { href: "/api/events/ics", label: "Events calendar (.ics)" },
   ],
   Policies: [
     { href: "/terms", label: "Terms" },
@@ -16,54 +16,90 @@ const footerLinks = {
   ],
   Support: [
     { href: "mailto:info@haiticity.org", label: "info@haiticity.org" },
-    { href: "/issues/new", label: "Report an Issue" },
+    { href: "/issues/new", label: "Report an issue" },
   ],
 } as const;
 
 export default function Footer() {
   const year = new Date().getFullYear();
   return (
-    <footer className="mt-20 border-t border-white/10 bg-slate-950/70 text-slate-200 backdrop-blur">
-      <div className="mx-auto max-w-6xl px-4 py-12 sm:px-6">
-        <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-4">
-          {Object.entries(footerLinks).map(([section, links]) => (
-            <div key={section}>
-              <h2 className="text-sm font-semibold uppercase tracking-wide text-cyan-200">
-                {section}
-              </h2>
-              <ul className="mt-3 space-y-2 text-sm text-slate-300">
-                {links.map((link) => (
-                  <li key={link.href}>
-                    {link.href.startsWith("mailto:") ? (
-                      <a
-                        href={link.href}
-                        className="inline-flex items-center gap-1 rounded-md px-1 py-0.5 transition hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
-                      >
-                        {link.label}
-                      </a>
-                    ) : (
-                      <Link
-                        href={link.href}
-                        className="inline-flex items-center gap-1 rounded-md px-1 py-0.5 transition hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
-                      >
-                        {link.label}
-                      </Link>
-                    )}
-                  </li>
-                ))}
-              </ul>
+    <footer className="mt-24 border-t border-white/10 bg-slate-950/80 text-slate-200 backdrop-blur">
+      <div className="mx-auto w-full max-w-6xl px-4 py-14 sm:px-6 lg:px-8">
+        <div className="grid gap-12 lg:grid-cols-[minmax(0,1.25fr)_minmax(0,2fr)]">
+          <div className="space-y-5">
+            <Link
+              href="/"
+              className="group inline-flex items-center gap-3 text-lg font-semibold text-white transition focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
+            >
+              <span
+                aria-hidden
+                className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-sky-500/80 to-orange-400/80 text-sm font-bold uppercase tracking-wide text-white shadow-md ring-1 ring-white/20 transition group-hover:shadow-lg"
+              >
+                HT
+              </span>
+              <span className="leading-tight">
+                Haiti City Portal
+                <span className="block text-xs font-normal text-slate-300">Municipal innovation hub</span>
+              </span>
+            </Link>
+            <p className="max-w-md text-sm text-slate-300">
+              A digital platform connecting residents with civic services, data, and events across the municipality. Built in partnership with local government and community leaders.
+            </p>
+            <div className="flex flex-wrap gap-3 text-xs font-semibold uppercase tracking-wide text-slate-400">
+              <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1">
+                <span className="flex h-2 w-2 rounded-full bg-emerald-400" aria-hidden />
+                Always-on support
+              </span>
+              <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1">
+                <span className="flex h-2 w-2 rounded-full bg-sky-400" aria-hidden />
+                Multilingual access
+              </span>
             </div>
-          ))}
+          </div>
+          <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-4">
+            {Object.entries(footerLinks).map(([section, links]) => (
+              <div key={section} className="space-y-3">
+                <h2 className="text-sm font-semibold uppercase tracking-wide text-cyan-200">{section}</h2>
+                <ul className="space-y-2 text-sm text-slate-300">
+                  {links.map((link) => (
+                    <li key={link.href}>
+                      {link.href.startsWith("mailto:") ? (
+                        <a
+                          href={link.href}
+                          className="inline-flex items-center gap-1 rounded-md px-1 py-0.5 transition hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
+                        >
+                          {link.label}
+                        </a>
+                      ) : (
+                        <Link
+                          href={link.href}
+                          className="inline-flex items-center gap-1 rounded-md px-1 py-0.5 transition hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
+                        >
+                          {link.label}
+                        </Link>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
         </div>
-        <div className="mt-10 flex flex-col gap-4 border-t border-white/10 pt-6 text-sm sm:flex-row sm:items-center sm:justify-between">
-          <p className="text-slate-400">© {year} Haiti City Portal. All rights reserved.</p>
-          <div className="flex items-center gap-4">
+        <div className="mt-12 flex flex-col gap-4 border-t border-white/10 pt-6 text-sm text-slate-400 sm:flex-row sm:items-center sm:justify-between">
+          <p>© {year} Haiti City Portal. All rights reserved.</p>
+          <div className="flex flex-wrap items-center gap-4">
             <LocaleSwitcher />
             <Link
-              href="/data"
-              className="rounded-md border border-white/15 px-3 py-1 text-sm text-slate-200 transition hover:border-cyan-300 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
+              href="/accessibility"
+              className="rounded-md border border-white/10 px-3 py-1 text-slate-200 transition hover:border-cyan-300 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
             >
-              Open Data
+              Accessibility
+            </Link>
+            <Link
+              href="mailto:info@haiticity.org"
+              className="rounded-md border border-white/10 px-3 py-1 text-slate-200 transition hover:border-cyan-300 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
+            >
+              Feedback
             </Link>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- guard Supabase server helper cookie writes during server component renders and expose a write-enabled variant for actions
- refresh spacing and hero cards across issues, events, data, and admin pages for consistent padding
- redesign the site footer with clearer branding and secondary links

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f4259624f4832b91a862913f9b5da5