### PR TITLE
Add localized content pages for about, privacy, terms, and tech

### DIFF
--- a/src/app/[locale]/(public)/privacy/page.tsx
+++ b/src/app/[locale]/(public)/privacy/page.tsx
@@ -3,8 +3,9 @@ import { InfoLayout } from "@/components/layout/InfoLayout";
 
 export const dynamic = "force-static";
 
-export default async function PrivacyPage() {
-  const entry = await loadContent("privacy");
+export default async function PrivacyPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const entry = await loadContent("privacy", locale);
   return (
     <InfoLayout title={entry.title}>
       <MarkdownRenderer content={entry.body} />

--- a/src/app/[locale]/(public)/terms/page.tsx
+++ b/src/app/[locale]/(public)/terms/page.tsx
@@ -3,8 +3,9 @@ import { InfoLayout } from "@/components/layout/InfoLayout";
 
 export const dynamic = "force-static";
 
-export default async function TermsPage() {
-  const entry = await loadContent("terms");
+export default async function TermsPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  const entry = await loadContent("terms", locale);
   return (
     <InfoLayout title={entry.title}>
       <MarkdownRenderer content={entry.body} />

--- a/src/content/about.es.mdx
+++ b/src/content/about.es.mdx
@@ -1,0 +1,13 @@
+# Acerca de Haiti City Portal
+
+Haiti City Portal es una plataforma cívica que conecta a los residentes con servicios locales, datos y oportunidades de colaboración. Trabajamos junto con equipos municipales y organizaciones comunitarias para agilizar la prestación de servicios públicos y hacer que la información local sea más fácil de acceder.
+
+## Nuestra misión
+
+- Modernizar cómo los residentes reportan problemas y reciben actualizaciones
+- Proporcionar acceso transparente a conjuntos de datos abiertos y mapas
+- Coordinar información sobre alcance comunitario, eventos e información de emergencias
+
+## Contacto
+
+¿Preguntas o sugerencias? Envía un email a **info@haiticity.org** o visita nuestra página de contacto para solicitar soporte.

--- a/src/content/about.fr.mdx
+++ b/src/content/about.fr.mdx
@@ -1,0 +1,13 @@
+# À propos de Haiti City Portal
+
+Haiti City Portal est une plateforme civique qui relie les résidents aux services locaux, aux données et aux opportunités de collaboration. Nous travaillons aux côtés des équipes municipales et des organisations communautaires pour rationaliser la prestation des services publics et rendre l'information locale plus facile d'accès.
+
+## Notre mission
+
+- Moderniser la façon dont les résidents signalent les problèmes et reçoivent des mises à jour
+- Fournir un accès transparent aux ensembles de données ouverts et aux cartes
+- Coordonner l'information sur les événements communautaires, les événements et les urgences
+
+## Contact
+
+Des questions ou des suggestions ? Envoyez un email à **info@haiticity.org** ou visitez notre page de contact pour demander du soutien.

--- a/src/content/about.ht.mdx
+++ b/src/content/about.ht.mdx
@@ -1,0 +1,13 @@
+# Konsènan Haiti City Portal
+
+Haiti City Portal se yon platfòm sivik ki konekte rezidan yo ak sèvis lokal yo, done yo ak opòtinite pou kolaborasyon. Nou travay ansanm ak ekip minisipal yo ak òganizasyon kominotè yo pou rasyonalize livrezon sèvis piblik yo epi fè enfòmasyon lokal yo pi fasil pou jwenn.
+
+## Misyon nou
+
+- Modènize fason rezidan yo rapòte pwoblèm yo epi resevwa mizajou
+- Bay aksè transparan a done ouvè ak kat
+- Kòdone enfòmasyon sou outreach kominotè, evènman ak enfòmasyon ijans
+
+## Kontak
+
+Kesyon oswa sijesyon? Voye yon imèl bay **info@haiticity.org** oswa vizite paj kontak nou an pou mande sipò.

--- a/src/content/privacy.es.mdx
+++ b/src/content/privacy.es.mdx
@@ -1,0 +1,17 @@
+# Política de Privacidad
+
+Respetamos su privacidad y solo recopilamos información necesaria para entregar servicios municipales.
+
+## Lo que recopilamos
+
+- Detalles que proporciona en formularios, como información de contacto
+- Análisis de uso para mejorar la confiabilidad del sistema
+- Archivos subidos para problemas o solicitudes de título
+
+## Cómo usamos los datos
+
+Usamos los datos para comunicarnos con usted sobre solicitudes, coordinar respuestas de servicios y publicar estadísticas agregadas. No vendemos datos personales a terceros.
+
+## Sus opciones
+
+Puede solicitar la eliminación de datos personales o darse de baja de las comunicaciones enviando un email a **privacy@haiticity.org**.

--- a/src/content/privacy.fr.mdx
+++ b/src/content/privacy.fr.mdx
@@ -1,0 +1,17 @@
+# Politique de Confidentialité
+
+Nous respectons votre vie privée et ne collectons que les informations nécessaires pour fournir des services municipaux.
+
+## Ce que nous collectons
+
+- Les détails que vous fournissez sur les formulaires, tels que les informations de contact
+- Les analyses d'utilisation pour améliorer la fiabilité du système
+- Les fichiers téléchargés pour les problèmes ou les demandes de titre
+
+## Comment nous utilisons les données
+
+Nous utilisons les données pour communiquer avec vous concernant les demandes, coordonner les réponses des services et publier des statistiques agrégées. Nous ne vendons pas de données personnelles à des tiers.
+
+## Vos choix
+
+Vous pouvez demander la suppression de données personnelles ou vous désinscrire des communications en envoyant un email à **privacy@haiticity.org**.

--- a/src/content/privacy.ht.mdx
+++ b/src/content/privacy.ht.mdx
@@ -1,0 +1,17 @@
+# Règleman sou Konfidansyalite
+
+Nou respekte vi prive ou epi nou sèlman kolekte enfòmasyon ki nesesè pou bay sèvis minisipal yo.
+
+## Sa nou kolekte
+
+- Detay ou bay sou fòm yo, tankou enfòmasyon kontak
+- Analiz itilizasyon pou amelyore fyab sistèm nan
+- Fichye yo telechaje pou pwoblèm oswa demann tit
+
+## Kòman nou itilize done yo
+
+Nou itilize done yo pou kominike avèk ou konsènan demann yo, kòdone repons sèvis yo, epi pibliye estatistik agrège. Nou pa vann done pèsonèl bay twazyèm pati.
+
+## Chwa ou yo
+
+Ou ka mande pou efase done pèsonèl oswa retire ou nan kominikasyon yo lè ou voye yon imèl bay **privacy@haiticity.org**.

--- a/src/content/tech.es.mdx
+++ b/src/content/tech.es.mdx
@@ -1,0 +1,9 @@
+# El Manifiesto de la Fuente Soberana
+
+**Diseño 2G Primero**: Optimizamos para el denominador común más bajo de la conectividad haitiana. Si una página no se carga en una red Edge en una sección comunal rural, es un error.
+
+**Responsabilidad Profesional**: Cada funcionario municipal está vinculado a un perfil Vwa verificado, convirtiendo la gobernanza local en una trayectoria profesional.
+
+**Soberanía de Datos**: Construido con BSL 1.1, esta plataforma asegura que los datos municipales haitianos pertenezcan al municipio, no a entidades comerciales extranjeras.
+
+**Transparencia como Código**: Los registros de auditoría y las estructuras de tarifas están integrados en la interfaz de usuario, haciendo que la corrupción sea más difícil de ocultar y el éxito más fácil de ver.

--- a/src/content/tech.fr.mdx
+++ b/src/content/tech.fr.mdx
@@ -1,0 +1,9 @@
+# Le Manifeste de la Source Souveraine
+
+**Conception 2G d'Abord** : Nous optimisons pour le plus petit dénominateur commun de la connectivité haïtienne. Si une page ne se charge pas sur un réseau Edge dans une section communale rurale, c'est un bug.
+
+**Responsabilité Professionnelle** : Chaque élu municipal est lié à un profil Vwa vérifié, transformant la gouvernance locale en un parcours professionnel.
+
+**Souveraineté des Données** : Construit avec BSL 1.1, cette plateforme garantit que les données municipales haïtiennes appartiennent à la municipalité, et non à des entités commerciales étrangères.
+
+**La Transparence comme Code** : Les journaux d'audit et les structures de frais sont intégrés à l'interface utilisateur, rendant la corruption plus difficile à cacher et le succès plus facile à voir.

--- a/src/content/tech.ht.mdx
+++ b/src/content/tech.ht.mdx
@@ -1,0 +1,9 @@
+# Manifeste Sous Souvren an
+
+**Konsepsyon 2G Premye** : Nou optimize pou pi piti denominateur komen nan koneksyon ayisyen an. Si yon paj pa chaje sou yon rezo Edge nan yon seksyon kominal riral, se yon bug.
+
+**Responsabilite Pwofesyonèl** : Chak ofisyèl minisipal konekte ak yon pwofil Vwa ki verifye, ki transforme gouvènans lokal la nan yon chemen karyè pwofesyonèl.
+
+**Souverenite Done** : Konstwi ak BSL 1.1, platfòm sa a asire ke done minisipal ayisyen yo ki pou minisipalite a, pa pou antite komèsyal etranje.
+
+**Transparans kòm Kòd** : Jounal odit yo ak estrikti frè yo entegre nan UI a, ki fè koripsyon pi difisil pou kache epi siksè pi fasil pou wè.

--- a/src/content/terms.es.mdx
+++ b/src/content/terms.es.mdx
@@ -1,0 +1,17 @@
+# Términos de Uso
+
+Al usar Haiti City Portal, acepta los siguientes términos.
+
+## Uso aceptable
+
+- Enviar información precisa sobre problemas y solicitudes
+- Respetar la privacidad de otros residentes
+- No intentar interrumpir el servicio o acceder a datos restringidos
+
+## Responsabilidad
+
+Haiti City Portal proporciona información "tal cual" sin garantías. El municipio no es responsable de daños que surjan de la confianza en este sitio.
+
+## Cambios
+
+Podemos actualizar estos términos periódicamente. El uso continuo del portal significa que acepta la versión más reciente.

--- a/src/content/terms.fr.mdx
+++ b/src/content/terms.fr.mdx
@@ -1,0 +1,17 @@
+# Conditions d'Utilisation
+
+En utilisant Haiti City Portal, vous acceptez les conditions suivantes.
+
+## Utilisation acceptable
+
+- Soumettre des informations précises sur les problèmes et les demandes
+- Respecter la vie privée des autres résidents
+- Ne pas tenter de perturber le service ou d'accéder à des données restreintes
+
+## Responsabilité
+
+Haiti City Portal fournit des informations "telles quelles" sans garanties. La municipalité n'est pas responsable des dommages découlant de la confiance accordée à ce site.
+
+## Modifications
+
+Nous pouvons mettre à jour ces conditions périodiquement. L'utilisation continue du portail signifie que vous acceptez la dernière version.

--- a/src/content/terms.ht.mdx
+++ b/src/content/terms.ht.mdx
@@ -1,0 +1,17 @@
+# Kondisyon Itilizasyon
+
+Lè ou itilize Haiti City Portal, ou dakò ak kondisyon sa yo.
+
+## Itilizasyon akseptab
+
+- Soumèt enfòmasyon egzak sou pwoblèm ak demann yo
+- Respekte vi prive lòt rezidan yo
+- Pa eseye deranje sèvis la oswa jwenn aksè a done restriksyon
+
+## Responsabilite
+
+Haiti City Portal bay enfòmasyon "jan li ye" san garanti. Minisipalite a pa responsab pou domaj ki soti nan konfyans nan sit sa a.
+
+## Chanjman
+
+Nou ka mete ajou kondisyon sa yo peryodikman. Itilizasyon kontinyèl pòtal la vle di ou aksepte dènye vèsyon an.


### PR DESCRIPTION
- Add French, Haitian Creole, and Spanish translations for about.mdx
- Add French, Haitian Creole, and Spanish translations for privacy.mdx
- Add French, Haitian Creole, and Spanish translations for terms.mdx
- Add French, Haitian Creole, and Spanish translations for tech.mdx
- Fix privacy and terms pages to properly pass locale to loadContent function
- Fixes #11

## What does this PR do?
Adds comprehensive localization support for static content pages across the Haiti City Portal. The original issue was about the about page not displaying in different languages, but I discovered this affected multiple pages.



## Related Issue
Closes #11 

## Checklist
- [x] I tested my changes
- [x] I updated documentation if needed
- [x] This PR is focused and scoped
