### PR TITLE
docs: add multilingual documentation hub (EN/FR/HT/ES)

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,96 @@
+# =============================================================================
+# Haiti City Portal — production environment template
+# =============================================================================
+#
+# Copy this file's variables into your hosting provider's environment-variable
+# settings (Vercel: Settings → Environment Variables). DO NOT commit a real
+# .env.production file with secrets to Git.
+#
+# See docs/DEPLOYMENT.md for full step-by-step deployment instructions.
+# =============================================================================
+
+
+# -----------------------------------------------------------------------------
+# REQUIRED — Database
+# -----------------------------------------------------------------------------
+# Production PostgreSQL connection string. We recommend Neon (https://neon.tech).
+# Make sure the URL ends with `?sslmode=require`.
+DATABASE_URL="postgresql://USER:PASSWORD@ep-xxx.us-east-2.aws.neon.tech/neondb?sslmode=require"
+
+
+# -----------------------------------------------------------------------------
+# REQUIRED — Authentication
+# -----------------------------------------------------------------------------
+# A random string used by NextAuth to sign sessions and JWTs.
+# Generate one with:
+#   openssl rand -base64 32
+# Must be at least 32 characters. Rotating this value signs out every active
+# session — use a password manager and never share it.
+AUTH_SECRET="REPLACE_ME_with_output_of_openssl_rand_base64_32"
+
+# The canonical URL of your deployment, including https://, no trailing slash.
+# This is your apex domain — the per-tenant subdomains derive from it.
+NEXTAUTH_URL="https://portal.ht"
+
+# Required when running behind a proxy (Vercel, Cloudflare, etc.).
+AUTH_TRUST_HOST="true"
+
+
+# -----------------------------------------------------------------------------
+# RECOMMENDED — Public base URL
+# -----------------------------------------------------------------------------
+# Used by client-side code that needs to construct absolute URLs.
+# Keep in sync with NEXTAUTH_URL.
+NEXT_PUBLIC_BASE_URL="https://portal.ht"
+
+
+# -----------------------------------------------------------------------------
+# DO NOT SET IN PRODUCTION — Local-mode toggle
+# -----------------------------------------------------------------------------
+# This variable is for local development only. It bypasses the database and
+# serves a static fallback tenant. Setting it in production will break the app.
+# Leave it commented or unset.
+#
+# ENABLE_LOCAL_MODE="false"
+
+
+# -----------------------------------------------------------------------------
+# OPTIONAL — Email service (e.g. for password reset, admin invites)
+# -----------------------------------------------------------------------------
+# Pick one provider. Resend is the simplest to set up.
+# RESEND_API_KEY=""
+# EMAIL_FROM="Haiti City Portal <noreply@portal.ht>"
+
+
+# -----------------------------------------------------------------------------
+# OPTIONAL — Error monitoring
+# -----------------------------------------------------------------------------
+# Sentry DSN if you set up error tracking.
+# NEXT_PUBLIC_SENTRY_DSN=""
+# SENTRY_DSN=""
+
+
+# -----------------------------------------------------------------------------
+# OPTIONAL — File storage (for resident photo uploads, official photos, etc.)
+# -----------------------------------------------------------------------------
+# Vercel Blob, AWS S3, or Cloudflare R2 are common choices.
+# BLOB_READ_WRITE_TOKEN=""    # Vercel Blob
+# S3_BUCKET=""
+# S3_ACCESS_KEY_ID=""
+# S3_SECRET_ACCESS_KEY=""
+# S3_REGION=""
+
+
+# -----------------------------------------------------------------------------
+# OPTIONAL — Map provider
+# -----------------------------------------------------------------------------
+# By default the portal uses MapLibre with free OpenStreetMap-derived tiles.
+# If you outgrow the free tier, add a Mapbox / Maptiler / Stadia key.
+# NEXT_PUBLIC_MAPTILER_KEY=""
+
+
+# -----------------------------------------------------------------------------
+# OPTIONAL — Per-tenant payment integrations (planned)
+# -----------------------------------------------------------------------------
+# Live MonCash / Stripe integration is on the roadmap. When enabled, secrets
+# are typically stored per-tenant in the database, not in env vars.

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 !.env.local.example
+!.env.production.example
 
 # vercel
 .vercel

--- a/CODE_OF_CONDUCT.es.md
+++ b/CODE_OF_CONDUCT.es.md
@@ -1,0 +1,128 @@
+<!--
+Idiomas: English (CODE_OF_CONDUCT.md) | Français (CODE_OF_CONDUCT.fr.md) | Kreyòl (CODE_OF_CONDUCT.ht.md) | Español (este archivo)
+-->
+
+**Idiomas:** [English](CODE_OF_CONDUCT.md) · [Français](CODE_OF_CONDUCT.fr.md) · [Kreyòl Ayisyen](CODE_OF_CONDUCT.ht.md) · **Español**
+
+[← README del proyecto](README.md) · [Índice de documentación](docs/README.es.md)
+
+---
+
+# Código de Conducta — Contributor Covenant
+
+## Índice
+
+- [Nuestro compromiso](#nuestro-compromiso)
+- [Nuestros estándares](#nuestros-estándares)
+- [Responsabilidades de aplicación](#responsabilidades-de-aplicación)
+- [Alcance](#alcance)
+- [Aplicación](#aplicación)
+- [Pautas de aplicación](#pautas-de-aplicación)
+- [Atribución](#atribución)
+
+---
+
+## Nuestro compromiso
+
+Como miembros, colaboradores y líderes, nos comprometemos a hacer de la participación en Haiti City Portal una experiencia libre de acoso para todas las personas, sin importar la edad, el tamaño corporal, la discapacidad visible o invisible, la etnia, las características sexuales, la identidad y expresión de género, el nivel de experiencia, la educación, el estatus socioeconómico, la nacionalidad, la apariencia personal, la raza, la religión o la identidad y orientación sexual.
+
+Nos comprometemos a actuar e interactuar de manera que contribuya a una comunidad abierta, acogedora, diversa, inclusiva y sana — que respete particularmente la dignidad y experiencia vivida de los haitianos en Haití y en la diáspora.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Nuestros estándares
+
+Comportamientos positivos:
+
+- Mostrar empatía y amabilidad
+- Respetar opiniones, perspectivas y experiencias diferentes
+- Dar y aceptar feedback constructivo con elegancia
+- Aceptar responsabilidad y disculparse, aprender de los errores
+- Centrarse en lo mejor para la comunidad, especialmente residentes y comunas
+- Comunicar en lenguaje claro, ser paciente con recién llegados, no anglófonos nativos y no desarrolladores
+- Traducir, revisar y reconocer el trabajo de quienes escriben en criollo, francés, inglés o español
+
+Comportamientos inaceptables:
+
+- Lenguaje o imágenes sexualizadas, avances sexuales
+- Trolling, insultos, ataques personales o políticos
+- Acoso público o privado
+- Publicar información privada de otros sin permiso explícito
+- Bromas o lenguaje discriminatorio sobre haitianos, cultura haitiana, o cualquier nación/comunidad
+- Cualquier conducta razonablemente inapropiada en entorno profesional
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Responsabilidades de aplicación
+
+Los mantenedores del proyecto aclaran y hacen cumplir los estándares. Toman acciones correctivas apropiadas frente a comportamientos inapropiados, amenazantes, ofensivos o dañinos.
+
+Tienen el derecho y la responsabilidad de eliminar, editar o rechazar comentarios, commits, código, modificaciones de wiki, issues y otras contribuciones no alineadas con este Código, y comunicarán las razones cuando corresponda.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Alcance
+
+Este Código se aplica en todos los espacios comunitarios — repositorios GitHub, issues, pull requests, discusiones, canales sociales, encuentros presenciales o virtuales — y también cuando una persona representa oficialmente a la comunidad en espacios públicos.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Aplicación
+
+Los abusos, acosos o comportamientos inaceptables pueden reportarse a:
+
+- `conduct@haiticity.org`
+
+Todas las quejas serán revisadas con prontitud y equidad. La confidencialidad del denunciante está garantizada.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Pautas de aplicación
+
+### 1. Corrección
+
+**Impacto:** lenguaje inapropiado o conducta no bienvenida.
+**Consecuencia:** advertencia escrita privada. Disculpa pública posible.
+
+### 2. Advertencia
+
+**Impacto:** infracción por incidente único o serie de actos.
+**Consecuencia:** advertencia con consecuencias por reincidencia. Sin interacción con las personas implicadas durante un período. Reincidencia: suspensión o expulsión.
+
+### 3. Suspensión temporal
+
+**Impacto:** infracción seria, conducta inapropiada sostenida.
+**Consecuencia:** prohibición temporal de interacción con la comunidad.
+
+### 4. Expulsión permanente
+
+**Impacto:** patrón de violaciones, acoso, agresión contra clases de personas.
+**Consecuencia:** expulsión permanente.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Atribución
+
+Adaptado del [Contributor Covenant](https://www.contributor-covenant.org), versión 2.1, disponible en <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Pautas inspiradas en la [escalera de aplicación de Mozilla](https://github.com/mozilla/diversity).
+
+FAQ: <https://www.contributor-covenant.org/faq>. Traducciones: <https://www.contributor-covenant.org/translations>.
+
+[↑ Volver arriba](#índice)
+
+---
+
+[← README del proyecto](README.md) · [Índice de documentación](docs/README.es.md) · [Contribuir →](CONTRIBUTING.md)

--- a/CODE_OF_CONDUCT.fr.md
+++ b/CODE_OF_CONDUCT.fr.md
@@ -1,0 +1,128 @@
+<!--
+Langues : English (CODE_OF_CONDUCT.md) | Français (ce fichier) | Kreyòl (CODE_OF_CONDUCT.ht.md) | Español (CODE_OF_CONDUCT.es.md)
+-->
+
+**Langues :** [English](CODE_OF_CONDUCT.md) · **Français** · [Kreyòl Ayisyen](CODE_OF_CONDUCT.ht.md) · [Español](CODE_OF_CONDUCT.es.md)
+
+[← README du projet](README.md) · [Index de la documentation](docs/README.fr.md)
+
+---
+
+# Code de conduite — Contributor Covenant
+
+## Sommaire
+
+- [Notre engagement](#notre-engagement)
+- [Nos standards](#nos-standards)
+- [Responsabilités d'application](#responsabilités-dapplication)
+- [Champ d'application](#champ-dapplication)
+- [Application](#application)
+- [Lignes directrices d'application](#lignes-directrices-dapplication)
+- [Attribution](#attribution)
+
+---
+
+## Notre engagement
+
+En tant que membres, contributeurs et leaders, nous nous engageons à faire de la participation à Haiti City Portal une expérience exempte de harcèlement pour toutes et tous, sans considération d'âge, de corpulence, de handicap visible ou invisible, d'ethnicité, de caractéristiques sexuelles, d'identité ou d'expression de genre, de niveau d'expérience, d'éducation, de statut socio-économique, de nationalité, d'apparence, de race, de religion ou d'identité et orientation sexuelle.
+
+Nous nous engageons à agir et interagir d'une manière qui contribue à une communauté ouverte, accueillante, diverse, inclusive et saine — qui respecte particulièrement la dignité et l'expérience vécue des Haïtiens en Haïti et dans la diaspora.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Nos standards
+
+Comportements positifs :
+
+- Empathie et bienveillance envers autrui
+- Respect des opinions, points de vue et expériences différentes
+- Donner et accepter avec grâce des retours constructifs
+- Assumer la responsabilité de nos erreurs, présenter des excuses et apprendre
+- Privilégier l'intérêt de la communauté, surtout les résidents et communes desservies
+- Communiquer en langage clair, être patient avec les nouveaux venus, les non-anglophones natifs et les non-développeurs
+- Traduire, relire et reconnaître le travail des contributeurs en créole, français, anglais ou espagnol
+
+Comportements inacceptables :
+
+- Langage ou imagerie sexualisés, avances sexuelles
+- Trolling, insultes, attaques personnelles ou politiques
+- Harcèlement public ou privé
+- Publication d'informations privées d'autrui sans permission explicite
+- Plaisanteries ou propos discriminatoires sur les Haïtiens, la culture haïtienne, ou toute nation/communauté
+- Toute conduite déraisonnablement inappropriée en cadre professionnel
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Responsabilités d'application
+
+Les mainteneurs clarifient et font appliquer ces standards. Ils prennent les actions correctives appropriées face à tout comportement jugé inapproprié, menaçant, offensant ou nuisible.
+
+Ils ont le droit et la responsabilité de retirer, modifier ou rejeter commentaires, commits, code, modifications de wiki, issues et autres contributions non alignées avec ce code, et expliqueront leurs décisions de modération quand utile.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Champ d'application
+
+Ce code s'applique à tous les espaces communautaires — dépôts GitHub, issues, pull requests, discussions, canaux sociaux, rencontres en personne ou virtuelles — ainsi que lorsqu'une personne représente officiellement la communauté dans des espaces publics.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Application
+
+Les abus, harcèlements ou comportements inacceptables peuvent être signalés à :
+
+- `conduct@haiticity.org`
+
+Toutes les plaintes seront examinées rapidement et équitablement. La confidentialité du signalement est garantie.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Lignes directrices d'application
+
+### 1. Correction
+
+**Impact :** langage inapproprié ou comportement non bienvenu.
+**Conséquence :** avertissement écrit privé. Excuses publiques possibles.
+
+### 2. Avertissement
+
+**Impact :** infraction par incident isolé ou série d'actes.
+**Conséquence :** avertissement avec conséquences en cas de récidive. Pas d'interaction avec les personnes impliquées pendant une période déterminée. Récidive : suspension ou bannissement.
+
+### 3. Suspension temporaire
+
+**Impact :** infraction grave, comportement inapproprié soutenu.
+**Conséquence :** interdiction temporaire d'interaction avec la communauté.
+
+### 4. Bannissement permanent
+
+**Impact :** schéma de violations, harcèlement, agression contre des classes de personnes.
+**Conséquence :** bannissement permanent.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Attribution
+
+Adapté du [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, disponible à <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Lignes directrices inspirées de [l'échelle d'application de Mozilla](https://github.com/mozilla/diversity).
+
+FAQ : <https://www.contributor-covenant.org/faq>. Traductions : <https://www.contributor-covenant.org/translations>.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+[← README du projet](README.md) · [Index de la documentation](docs/README.fr.md) · [Contribuer →](CONTRIBUTING.md)

--- a/CODE_OF_CONDUCT.ht.md
+++ b/CODE_OF_CONDUCT.ht.md
@@ -1,0 +1,128 @@
+<!--
+Lang yo: English (CODE_OF_CONDUCT.md) | Français (CODE_OF_CONDUCT.fr.md) | Kreyòl (fichye sa a) | Español (CODE_OF_CONDUCT.es.md)
+-->
+
+**Lang yo:** [English](CODE_OF_CONDUCT.md) · [Français](CODE_OF_CONDUCT.fr.md) · **Kreyòl Ayisyen** · [Español](CODE_OF_CONDUCT.es.md)
+
+[← README pwojè a](README.md) · [Endèks dokimantasyon](docs/README.ht.md)
+
+---
+
+# Kòd Kondwit — Contributor Covenant
+
+## Tablo Kontni
+
+- [Angajman nou](#angajman-nou)
+- [Estanda nou](#estanda-nou)
+- [Responsablite aplikasyon](#responsablite-aplikasyon)
+- [Chan aplikasyon](#chan-aplikasyon)
+- [Aplikasyon](#aplikasyon)
+- [Direktiv aplikasyon](#direktiv-aplikasyon)
+- [Atribisyon](#atribisyon)
+
+---
+
+## Angajman nou
+
+Kòm manm, kontribitè ak lidè, nou angaje fè patisipasyon nan Haiti City Portal yon eksperyans san asèlman pou tout moun, kèlkeswa laj, gwosè, andikap vizib oswa envizib, etnisite, karakteristik sèksyèl, idantite oswa ekspresyon jan, nivo eksperyans, edikasyon, estati sosyo-ekonomik, nasyonalite, aparans, ras, relijyon, oswa idantite ak oryantasyon sèksyèl.
+
+Nou angaje aji ak entèraji nan yon fason ki kontribye nan yon kominote louvri, akeyan, divès, enklizif ak an sante — ki respekte espesyalman diyite ak eksperyans Ayisyen nan Ayiti ak nan dyaspora a.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Estanda nou
+
+Konpòtman pozitif:
+
+- Empathy ak janti ak lòt moun
+- Respekte opinyon, pwennvi ak eksperyans diferan
+- Bay ak aksepte feedback konstriktif ak elegans
+- Aksepte responsablite, mande padon, epi aprann
+- Konsantre sou sa ki pi bon pou kominote a, espesyalman rezidan ak komin pòtal la sèvi
+- Kominike an lang senp, gen pasyans ak nouvo moun, moun ki pa anglofòn natif, ak moun ki pa devlopè
+- Tradwi, revize, epi rekonèt travay kontribitè ki ekri an kreyòl, franse, anglè oswa espanyòl
+
+Konpòtman ki pa akseptab:
+
+- Lang oswa imaj sèksyalize, avans sèksyèl
+- Trolling, joure, atak pèsonèl oswa politik
+- Asèlman piblik oswa prive
+- Pibliye enfòmasyon prive lòt moun san pèmisyon
+- Blag oswa lang diskriminatwa sou Ayisyen, kilti ayisyen, oswa nenpòt nasyon/kominote
+- Tout konpòtman rezonabman pa apwopriye nan kad pwofesyonèl
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Responsablite aplikasyon
+
+Mainteneur klarifye epi fè respekte estanda yo. Yo pran aksyon korektif apwopriye fas ak nenpòt konpòtman jije pa apwopriye, menasan, ofansif oswa danjere.
+
+Yo gen dwa epi responsablite retire, modifye oswa rejte kòmantè, commits, kòd, modifikasyon wiki, issues, ak lòt kontribisyon ki pa aliyen ak kòd sa a, epi yo ap kominike rezon yo lè li itil.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Chan aplikasyon
+
+Kòd sa aplike nan tout espas kominote — depo GitHub, issues, pull requests, diskisyon, kanal sosyal, rankont anpèsòn oswa vityèl — epi tou lè yon moun ofisyèlman reprezante kominote a nan espas piblik.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Aplikasyon
+
+Abi, asèlman oswa konpòtman pa akseptab ka rapòte bay:
+
+- `conduct@haiticity.org`
+
+Tout plent ap revize rapidman epi jistman. Konfidansyalite moun k ap rapòte garanti.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Direktiv aplikasyon
+
+### 1. Koreksyon
+
+**Enpak:** lang ki pa apwopriye oswa konpòtman ki pa byenveni.
+**Konsekans:** avètisman ekri prive. Padon piblik posib.
+
+### 2. Avètisman
+
+**Enpak:** vyolasyon pa yon ensidan oswa seri zak.
+**Konsekans:** avètisman ak konsekans si rekiran. Pa gen entèraksyon ak moun yo enplike pou yon peryòd. Rekiran: sispansyon oswa banisman.
+
+### 3. Sispansyon tanporè
+
+**Enpak:** vyolasyon serye, konpòtman pa apwopriye soutni.
+**Konsekans:** entèdiksyon tanporè entèraksyon ak kominote a.
+
+### 4. Banisman pèmanan
+
+**Enpak:** modèl vyolasyon, asèlman, agresyon kont klas moun.
+**Konsekans:** banisman pèmanan.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Atribisyon
+
+Adapte de [Contributor Covenant](https://www.contributor-covenant.org), vèsyon 2.1, disponib nan <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Direktiv enspire nan [echèl aplikasyon Mozilla](https://github.com/mozilla/diversity).
+
+FAQ: <https://www.contributor-covenant.org/faq>. Tradiksyon: <https://www.contributor-covenant.org/translations>.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+[← README pwojè a](README.md) · [Endèks dokimantasyon](docs/README.ht.md) · [Kontribye →](CONTRIBUTING.md)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,134 @@
+<!--
+Languages: English (this file) | Français (CODE_OF_CONDUCT.fr.md) | Kreyòl (CODE_OF_CONDUCT.ht.md) | Español (CODE_OF_CONDUCT.es.md)
+-->
+
+**Languages:** **English** · [Français](CODE_OF_CONDUCT.fr.md) · [Kreyòl Ayisyen](CODE_OF_CONDUCT.ht.md) · [Español](CODE_OF_CONDUCT.es.md)
+
+[← Project README](README.md) · [Docs index](docs/README.md)
+
+---
+
+# Contributor Covenant Code of Conduct
+
+## Table of Contents
+
+- [Our pledge](#our-pledge)
+- [Our standards](#our-standards)
+- [Enforcement responsibilities](#enforcement-responsibilities)
+- [Scope](#scope)
+- [Enforcement](#enforcement)
+- [Enforcement guidelines](#enforcement-guidelines)
+- [Attribution](#attribution)
+
+---
+
+## Our pledge
+
+We as members, contributors, and leaders pledge to make participation in Haiti City Portal a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community — particularly one that respects the dignity and lived experience of Haitians at home and in the diaspora.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Our standards
+
+Examples of behaviour that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologising to those affected by our mistakes, and learning from the experience
+- Focusing on what is best for the overall community, especially the residents and municipalities the project serves
+- Communicating in plain language and being patient with newcomers, including non-native English speakers and non-developers
+- Translating, reviewing, and acknowledging the work of contributors who write in Creole, French, English, or Spanish
+
+Examples of unacceptable behaviour include:
+
+- The use of sexualised language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Discriminatory jokes or language about Haitians, Haitian culture, or any nation or community
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Enforcement responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable behaviour and will take appropriate and fair corrective action in response to any behaviour that they deem inappropriate, threatening, offensive, or harmful.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Scope
+
+This Code of Conduct applies within all community spaces — GitHub repositories, issues, pull requests, discussions, project social channels, in-person and virtual meetups — and also applies when an individual is officially representing the community in public spaces.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported to the project maintainers responsible for enforcement at:
+
+- `conduct@haiticity.org`
+
+All complaints will be reviewed and investigated promptly and fairly. All maintainers are obligated to respect the privacy and security of the reporter of any incident.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Enforcement guidelines
+
+Project maintainers will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community impact:** Use of inappropriate language or other behaviour deemed unprofessional or unwelcome in the community.
+
+**Consequence:** A private, written warning, providing clarity around the nature of the violation and an explanation of why the behaviour was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community impact:** A violation through a single incident or series of actions.
+
+**Consequence:** A warning with consequences for continued behaviour. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary ban
+
+**Community impact:** A serious violation of community standards, including sustained inappropriate behaviour.
+
+**Consequence:** A temporary ban from any sort of interaction or public communication with the community for a specified period. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent ban
+
+**Community impact:** Demonstrating a pattern of violation of community standards, including sustained inappropriate behaviour, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence:** A permanent ban from any sort of public interaction within the community.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this Code of Conduct, see the FAQ at <https://www.contributor-covenant.org/faq>. Translations are available at <https://www.contributor-covenant.org/translations>.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+[← Project README](README.md) · [Docs index](docs/README.md) · [Contributing →](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 Next.js 15 + TypeScript civic portal for Haitian municipalities. Residents can report issues, access municipal services, pay fees, view officials, find facilities, and read local news — all in four languages.
 
+> **Documentation hub:** start at **[docs/README.md](docs/README.md)** for a role-based index covering deployment, tenant onboarding, admin manual, content guide, architecture, glossary, and more — available in **English · Français · Kreyòl · Español**.
+
+### Quick links by role
+
+- City staff / mayor → [For Municipalities](docs/FOR_MUNICIPALITIES.md)
+- Developer → [Architecture](docs/ARCHITECTURE.md) → [Contributing](CONTRIBUTING.md)
+- IT / sysadmin → [Deployment](docs/DEPLOYMENT.md) → [Tenant Onboarding](docs/TENANT_ONBOARDING.md)
+- Admin user → [Admin Manual](docs/ADMIN_MANUAL.md)
+- Translator → [Content Guide](docs/CONTENT_GUIDE.md)
+- Confused by a word → [Glossary](docs/GLOSSARY.md)
+
 ## Architecture: Headless Multi-Tenant SaaS
 
 One codebase serves multiple municipalities. Cities are identified by subdomain (e.g. `jacmel.portal.ht`). The middleware extracts the subdomain from the `Host` header, injects it as the `x-tenant-subdomain` request header, and every downstream Server Component reads that header to scope all database queries by `tenant_id`.
@@ -421,8 +432,34 @@ Set `CI=true` in your pipeline. Playwright will retry once on failure, limit wor
 
 ## Further Documentation
 
-- [docs/haiti-city-portal-prd.md](docs/haiti-city-portal-prd.md) — Product Requirements Document
-- [docs/technical-notes.md](docs/technical-notes.md) — Architecture deep-dives and implementation roadmap
+**Full multilingual documentation index → [docs/README.md](docs/README.md)** (English · Français · Kreyòl · Español)
+
+### Plain-language overviews
+
+- [docs/FOR_MUNICIPALITIES.md](docs/FOR_MUNICIPALITIES.md) — Non-technical: what this is, what you need, what it costs, who to contact
+- [docs/GLOSSARY.md](docs/GLOSSARY.md) — Plain definitions of every technical and Haitian-civic term
+- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) — Expected behaviour for contributors
+
+### Operations
+
+- [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) — Step-by-step: domain, DNS, hosting, database, first deploy
+- [docs/TENANT_ONBOARDING.md](docs/TENANT_ONBOARDING.md) — Add a new commune to a running deployment
+- [docs/ADMIN_MANUAL.md](docs/ADMIN_MANUAL.md) — Day-to-day admin panel guide for municipal staff
+- [docs/CONTENT_GUIDE.md](docs/CONTENT_GUIDE.md) — Translate/edit content via the GitHub web UI (no coding)
 - [docs/BRANCH_PROTECTION.md](docs/BRANCH_PROTECTION.md) — GitHub branch protection setup
+- [.env.production.example](.env.production.example) — Annotated production environment template
+
+### Engineering
+
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — One-page architecture overview with diagrams
+- [docs/technical-notes.md](docs/technical-notes.md) — Deep-dives: tenants, content, auth, payments, maps
+- [docs/haiti-city-portal-prd.md](docs/haiti-city-portal-prd.md) — Product Requirements Document
+- [docs/v0.1-implementation-plan.md](docs/v0.1-implementation-plan.md) — Implementation status checklist
+- [docs/adr/README.md](docs/adr/README.md) — Architecture Decision Records (the "why")
+- [copilot-instructions.md](copilot-instructions.md) — Hard rules for AI assistants and contributors
+
+### Policy
+
 - [CONTRIBUTING.md](CONTRIBUTING.md) — Contribution guidelines
 - [SECURITY.md](SECURITY.md) — Security policy and vulnerability reporting
+- [LICENSE.md](LICENSE.md) — Business Source License 1.1 (converts to Apache 2.0 on Dec 31, 2028)

--- a/docs/ADMIN_MANUAL.es.md
+++ b/docs/ADMIN_MANUAL.es.md
@@ -1,0 +1,246 @@
+<!--
+Idiomas: English (ADMIN_MANUAL.md) | Français (ADMIN_MANUAL.fr.md) | Kreyòl (ADMIN_MANUAL.ht.md) | Español (este archivo)
+-->
+
+**Idiomas:** [English](ADMIN_MANUAL.md) · [Français](ADMIN_MANUAL.fr.md) · [Kreyòl Ayisyen](ADMIN_MANUAL.ht.md) · **Español**
+
+[← Índice de documentación](README.es.md) · [README del proyecto](../README.md) · [Glosario](GLOSSARY.es.md)
+
+---
+
+# Manual de Administración
+
+Guía práctica de uso diario para personal municipal del panel de administración. No requiere formación técnica.
+
+## Índice
+
+- [Antes de empezar](#antes-de-empezar)
+- [Iniciar sesión](#iniciar-sesión)
+- [El tablero](#el-tablero)
+- [Solicitudes de servicio](#solicitudes-de-servicio)
+- [Verificar pagos](#verificar-pagos)
+- [Publicar noticias](#publicar-noticias)
+- [Publicar una alerta de emergencia](#publicar-una-alerta-de-emergencia)
+- [Gestionar oficiales](#gestionar-oficiales)
+- [Gestionar instalaciones](#gestionar-instalaciones)
+- [Revisar sugerencias](#revisar-sugerencias)
+- [Reportes de campo](#reportes-de-campo)
+- [Manual de gobernanza](#manual-de-gobernanza)
+- [Revisión de auditoría financiera](#revisión-de-auditoría-financiera)
+- [Roles de usuario y acceso](#roles-de-usuario-y-acceso)
+- [Cierre de sesión y traspaso](#cierre-de-sesión-y-traspaso)
+- [Solución de problemas](#solución-de-problemas)
+
+---
+
+## Antes de empezar
+
+Necesita:
+
+- Un navegador (Chrome, Edge, Safari, Firefox).
+- Sus credenciales admin (las da su líder de TI).
+- Internet.
+
+Recomendado: una segunda pantalla/pestaña para notas; lectura del [Glosario](GLOSSARY.es.md).
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Iniciar sesión
+
+1. Vaya a `https://{su-subdominio}.portal.ht`.
+2. Clic en **Login** o vaya a `/login`.
+3. Ingrese email y contraseña.
+4. Aterrizará en `/admin`.
+
+Si la contraseña no funciona, pida a su líder TI que la resetee. Nunca comparta su contraseña.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## El tablero
+
+`/admin` es su punto de partida cada día:
+
+- **Solicitudes abiertas**.
+- **Pagos pendientes**.
+- **Actividad reciente**.
+- **Accesos rápidos** a cada sección.
+
+Abra el tablero al iniciar la jornada.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Solicitudes de servicio
+
+### Leer una solicitud
+
+1. **Requests** o `/admin/requests`.
+2. La lista muestra: fecha, tipo, estado, resumen.
+3. Clic en una fila para ver `/admin/requests/[id]`: nombre, contacto, descripción, foto, GPS, historial.
+
+### Actualizar estado
+
+| Estado | Significado |
+|---|---|
+| **Open** | Recién enviada, sin atender |
+| **In progress** | Un agente está trabajando |
+| **Resolved** | Resuelta |
+| **Closed** | Resuelta y reconocida por el residente |
+| **Rejected** | No procede (fuera de alcance, duplicado, malicioso) — incluya razón |
+
+Clic **Update Status**, agregue una nota interna corta.
+
+### Buenas prácticas
+
+- Actualice antes de **48 h**, aunque sea un acuse.
+- Casos complejos: **In progress**, actualice de nuevo al final.
+- Rechazos: razón clara — protección legal.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Verificar pagos
+
+Hoy: reconciliación manual.
+
+### Procedimiento
+
+1. `/admin/finance`.
+2. Filtre estado **Pending Upload**.
+3. Abra: código memo, monto, método, contacto.
+4. Cruce contra extracto banco/MonCash.
+5. Si encuentra: **Mark Verified**, fecha real, captura opcional.
+6. Si no aparece tras 5 días hábiles: **Failed** con razón.
+
+> **Crítico:** nunca valide sin prueba independiente.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Publicar noticias
+
+Vea [Guía de Contenido](CONTENT_GUIDE.es.md) para el flujo GitHub web (recomendado). Un editor admin web está en hoja de ruta.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Publicar una alerta de emergencia
+
+1. `/admin/emergency` → **New Alert**.
+2. Título en los 4 idiomas, cuerpo, severidad (`info`/`warning`/`critical`), inicio, fin.
+3. Guardar.
+
+La alerta aparece de inmediato.
+
+> Duplique alertas críticas vía WhatsApp, radio, altavoces municipales. El portal complementa, no reemplaza.
+
+Para terminar antes: edite el fin o **Deactivate**.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Gestionar oficiales
+
+`/admin/officials`. Nuevo: nombre, rol, sección comunal, foto, WhatsApp, perfil Vwa. Inactivar en lugar de borrar.
+
+En cada elección, programe 2 h en los 7 días siguientes a la investidura.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Gestionar instalaciones
+
+`/admin/facilities`. Categorías: hospital, escuela, policía, bomberos, iglesia, mercado, gobierno, otra.
+
+GPS por teléfono o Google Maps (clic derecho → "¿Qué hay aquí?").
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Revisar sugerencias
+
+`/admin/facility-suggestions`. Aceptar o rechazar con razón. Limpieza semanal.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Reportes de campo
+
+`/admin/field-reports`. Tipo, lugar, descripción, foto, severidad. Alimenta el mapa `/map`.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Manual de gobernanza
+
+`/admin/handbook`. Lectura: todos los admins según rol. Edición: `superadmin` vía `/admin/handbook/editor`. Lectura registrada — útil para onboarding.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Revisión de auditoría financiera
+
+`/admin/finance/audit-review`. Snapshots automáticos. Compare mes actual / anterior. Anomalía → escale al tesorero. Página de solo lectura.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Roles de usuario y acceso
+
+| Rol | Puede |
+|---|---|
+| `user` | Enviar solicitudes, pagar |
+| `admin` | Solicitudes, pagos, oficiales/instalaciones, noticias/alertas |
+| `superadmin` | Todo admin + handbook + crear/desactivar admins |
+
+Al menos **dos `superadmin`** por comuna.
+
+Nuevo admin: `/admin/users` o Drizzle Studio. Nunca cuenta compartida.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Cierre de sesión y traspaso
+
+Fin de turno:
+1. Nota en **Open requests**.
+2. Mensaje Slack/WhatsApp al siguiente turno: urgencias, pagos, alertas activas.
+3. Avatar → **Logout**.
+4. Cierre la pestaña (dispositivos compartidos).
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Solución de problemas
+
+| Problema | Acción |
+|---|---|
+| Contraseña olvidada | Reset por el líder TI |
+| No veo el panel admin | Cuenta no admin — pida a un superadmin |
+| Pago verificado por error | **Reverse Verification** + razón |
+| Errata en noticia/alerta | Editar MDX/alerta |
+| Sitio caído | `/api/health`, si no avise al líder TI |
+| Veo datos de otra comuna | **Incidente crítico**: `security@haiticity.org` ya |
+
+[↑ Volver arriba](#índice)
+
+---
+
+[← Índice de documentación](README.es.md) · [Alta de Municipio](TENANT_ONBOARDING.es.md) · [Guía de Contenido →](CONTENT_GUIDE.es.md)

--- a/docs/ADMIN_MANUAL.fr.md
+++ b/docs/ADMIN_MANUAL.fr.md
@@ -1,0 +1,246 @@
+<!--
+Langues : English (ADMIN_MANUAL.md) | Français (ce fichier) | Kreyòl (ADMIN_MANUAL.ht.md) | Español (ADMIN_MANUAL.es.md)
+-->
+
+**Langues :** [English](ADMIN_MANUAL.md) · **Français** · [Kreyòl Ayisyen](ADMIN_MANUAL.ht.md) · [Español](ADMIN_MANUAL.es.md)
+
+[← Index de la documentation](README.fr.md) · [README du projet](../README.md) · [Glossaire](GLOSSARY.fr.md)
+
+---
+
+# Manuel d'administration
+
+Guide pratique au quotidien pour le personnel municipal qui utilise le panneau d'administration. Aucune connaissance technique requise.
+
+## Sommaire
+
+- [Avant de commencer](#avant-de-commencer)
+- [Connexion](#connexion)
+- [Le tableau de bord](#le-tableau-de-bord)
+- [Demandes de service](#demandes-de-service)
+- [Vérifier les paiements](#vérifier-les-paiements)
+- [Publier des actualités](#publier-des-actualités)
+- [Diffuser une alerte d'urgence](#diffuser-une-alerte-durgence)
+- [Gérer les élus](#gérer-les-élus)
+- [Gérer les installations](#gérer-les-installations)
+- [Examiner les suggestions](#examiner-les-suggestions)
+- [Rapports de terrain](#rapports-de-terrain)
+- [Manuel de gouvernance](#manuel-de-gouvernance)
+- [Revue d'audit financier](#revue-daudit-financier)
+- [Rôles utilisateurs et accès](#rôles-utilisateurs-et-accès)
+- [Déconnexion et passation](#déconnexion-et-passation)
+- [Dépannage](#dépannage)
+
+---
+
+## Avant de commencer
+
+Il vous faut :
+
+- Un navigateur (Chrome, Edge, Safari, Firefox).
+- Vos identifiants admin (donnés par votre responsable IT).
+- Internet.
+
+Recommandé : un deuxième écran/onglet pour les notes ; lecture du [Glossaire](GLOSSARY.fr.md).
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Connexion
+
+1. Allez sur `https://{votre-sous-domaine}.portal.ht`.
+2. Cliquez **Connexion** ou allez à `/login`.
+3. Saisissez votre e-mail et mot de passe.
+4. Vous arrivez sur `/admin`.
+
+Si le mot de passe ne marche pas, demandez à votre responsable IT de le réinitialiser. Ne partagez jamais votre mot de passe.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Le tableau de bord
+
+`/admin` est votre point de départ chaque jour :
+
+- **Demandes ouvertes**.
+- **Paiements en attente**.
+- **Activité récente**.
+- **Liens rapides** vers chaque section.
+
+Ouvrez le tableau de bord en arrivant le matin.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Demandes de service
+
+### Lire une demande
+
+1. **Requests** ou `/admin/requests`.
+2. La liste affiche : date, type, statut, résumé.
+3. Cliquez une ligne pour voir le détail à `/admin/requests/[id]` : nom, contact, description, photo, GPS, historique de statut.
+
+### Mettre à jour le statut
+
+| Statut | Sens |
+|---|---|
+| **Open** | Soumise, pas encore traitée |
+| **In progress** | Un agent y travaille |
+| **Resolved** | Réglée |
+| **Closed** | Résolue et reconnue par le résident |
+| **Rejected** | Pas exploitable (hors champ, doublon, malveillant) — joindre une raison |
+
+Cliquez **Update Status**, ajoutez une note interne courte.
+
+### Bonnes pratiques
+
+- Mise à jour sous **48 h**, même un simple accusé.
+- Cas complexes : statut **In progress**, puis nouvelle MAJ à la fin.
+- Rejets : raison claire — protection juridique.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Vérifier les paiements
+
+Aujourd'hui : réconciliation manuelle.
+
+### Procédure
+
+1. `/admin/finance`.
+2. Filtre statut **Pending Upload**.
+3. Ouvrez : code mémo, montant, méthode, contact.
+4. Croisez avec relevé bancaire/MonCash.
+5. Si trouvé : **Mark Verified**, date réelle, capture optionnelle.
+6. Si non trouvé sous 5 jours ouvrés : **Failed** avec raison.
+
+> **Critique :** ne validez jamais sans preuve indépendante.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Publier des actualités
+
+Voir [Guide de contenu](CONTENT_GUIDE.fr.md) pour la procédure GitHub web (recommandée). Un éditeur web admin est sur la feuille de route.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Diffuser une alerte d'urgence
+
+1. `/admin/emergency` → **New Alert**.
+2. Titre dans les 4 langues, corps, sévérité (`info`/`warning`/`critical`), début, fin.
+3. Sauver.
+
+L'alerte apparaît immédiatement.
+
+> Doublez les alertes critiques par WhatsApp, radio, haut-parleurs municipaux. Le portail complète, ne remplace pas.
+
+Pour terminer plus tôt : éditer la fin ou cliquer **Deactivate**.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Gérer les élus
+
+`/admin/officials`. Nouveau : nom, rôle, section communale, photo, WhatsApp, profil Vwa. Mettre inactif plutôt que supprimer.
+
+À chaque élection, prévoyez 2 h dans les 7 jours suivant l'investiture.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Gérer les installations
+
+`/admin/facilities`. Catégories : hôpital, école, police, pompiers, église, marché, gouvernement, autre.
+
+GPS via téléphone ou Google Maps (clic droit → « Plus d'infos sur cet endroit »).
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Examiner les suggestions
+
+`/admin/facility-suggestions`. Accepter ou rejeter avec raison. Vidange hebdomadaire conseillée.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Rapports de terrain
+
+`/admin/field-reports`. Type, lieu, description, photo, sévérité. Alimente la carte `/map`.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Manuel de gouvernance
+
+`/admin/handbook`. Lecture : tous les admins selon le rôle. Édition : `superadmin` via `/admin/handbook/editor`. Lecture trackée — utile pour l'onboarding.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Revue d'audit financier
+
+`/admin/finance/audit-review`. Snapshots automatiques. Comparez mois en cours / mois précédent. Anomalie → escaladez au trésorier. Page en lecture seule.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Rôles utilisateurs et accès
+
+| Rôle | Peut |
+|---|---|
+| `user` | Soumettre demandes, payer |
+| `admin` | Demandes, paiements, élus/installations, actus/alertes |
+| `superadmin` | Tout admin + handbook + créer/désactiver admins |
+
+Au moins **deux `superadmin`** par commune.
+
+Nouvel admin : `/admin/users` ou Drizzle Studio. Jamais de compte partagé.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Déconnexion et passation
+
+Fin de poste :
+1. Note dans **Open requests**.
+2. Message Slack/WhatsApp à l'équipe suivante : urgences, paiements, alertes actives.
+3. Avatar → **Logout**.
+4. Fermez l'onglet (postes partagés).
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Dépannage
+
+| Problème | Action |
+|---|---|
+| Mot de passe oublié | Réinitialisation par le responsable IT |
+| Pas d'admin panel | Compte non admin — demandez à un superadmin |
+| Paiement validé par erreur | **Reverse Verification** + raison |
+| Faute de frappe sur news/alerte | Re-éditer le MDX/l'alerte |
+| Site indisponible | `/api/health`, sinon IT lead |
+| Données d'une autre commune visibles | **Incident critique** : `security@haiticity.org` immédiatement |
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+[← Index de la documentation](README.fr.md) · [Intégration d'une commune](TENANT_ONBOARDING.fr.md) · [Guide de contenu →](CONTENT_GUIDE.fr.md)

--- a/docs/ADMIN_MANUAL.ht.md
+++ b/docs/ADMIN_MANUAL.ht.md
@@ -1,0 +1,246 @@
+<!--
+Lang yo: English (ADMIN_MANUAL.md) | Français (ADMIN_MANUAL.fr.md) | Kreyòl (fichye sa a) | Español (ADMIN_MANUAL.es.md)
+-->
+
+**Lang yo:** [English](ADMIN_MANUAL.md) · [Français](ADMIN_MANUAL.fr.md) · **Kreyòl Ayisyen** · [Español](ADMIN_MANUAL.es.md)
+
+[← Endèks dokimantasyon](README.ht.md) · [README pwojè a](../README.md) · [Glosè](GLOSSARY.ht.md)
+
+---
+
+# Manyèl Administrasyon
+
+Gid pratik pou anplwaye lameri k ap itilize panèl admin chak jou. Pa bezwen koneksans teknik.
+
+## Tablo Kontni
+
+- [Anvan w kòmanse](#anvan-w-kòmanse)
+- [Koneksyon](#koneksyon)
+- [Tablobò a](#tablobò-a)
+- [Demann sèvis](#demann-sèvis)
+- [Verifye peyman](#verifye-peyman)
+- [Pibliye nouvèl](#pibliye-nouvèl)
+- [Pibliye yon alèt ijans](#pibliye-yon-alèt-ijans)
+- [Jere ofisyèl](#jere-ofisyèl)
+- [Jere etablisman](#jere-etablisman)
+- [Egzamine sijesyon](#egzamine-sijesyon)
+- [Rapò teren](#rapò-teren)
+- [Manyèl gouvènans](#manyèl-gouvènans)
+- [Revizyon odit finans](#revizyon-odit-finans)
+- [Wòl itilizatè ak aksè](#wòl-itilizatè-ak-aksè)
+- [Dekonèksyon ak pasaj](#dekonèksyon-ak-pasaj)
+- [Rezolisyon pwoblèm](#rezolisyon-pwoblèm)
+
+---
+
+## Anvan w kòmanse
+
+Ou bezwen:
+
+- Yon navigatè (Chrome, Edge, Safari, Firefox).
+- Imèl ak modpas admin ou (lidè IT ou bay ou).
+- Entènèt.
+
+Rekòmande: yon dezyèm ekran/onglè pou nòt; li [Glosè](GLOSSARY.ht.md).
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Koneksyon
+
+1. Ale sou `https://{soudomèn-ou}.portal.ht`.
+2. Klike **Login** oswa ale `/login`.
+3. Antre imèl ak modpas.
+4. Ou rive sou `/admin`.
+
+Si modpas pa mache, mande lidè IT reseti l. Pa janm pataje modpas.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Tablobò a
+
+`/admin` se kote w kòmanse chak jou:
+
+- **Demann ouvri**.
+- **Peyman annatant**.
+- **Aktivite resan**.
+- **Lyen rapid** pou chak seksyon.
+
+Louvri tablobò a premye bagay nan maten.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Demann sèvis
+
+### Li yon demann
+
+1. **Requests** oswa `/admin/requests`.
+2. Lis la montre: dat, tip, estati, rezime.
+3. Klike yon liy pou wè detay nan `/admin/requests/[id]`: non, kontak, deskripsyon, foto, GPS, istorik estati.
+
+### Met estati ajou
+
+| Estati | Sans |
+|---|---|
+| **Open** | Soumèt, poko trete |
+| **In progress** | Yon anplwaye ap travay sou li |
+| **Resolved** | Rezoud |
+| **Closed** | Rezoud epi rezidan rekonèt |
+| **Rejected** | Pa egzekitab (deyò sijè, doub, malisye) — ajoute rezon |
+
+Klike **Update Status**, ajoute yon nòt entèn kout.
+
+### Pi bon pratik
+
+- Met ajou anvan **48 èdtan**, menm yon senp akize.
+- Ka konplèks: **In progress**, met ajou ankò lè fini.
+- Rejè: rezon klè — pwoteksyon legal.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Verifye peyman
+
+Jodi a: rekonsilyasyon manyèl.
+
+### Pwosedi
+
+1. `/admin/finance`.
+2. Filtre estati **Pending Upload**.
+3. Louvri: kòd memo, montan, metòd, kontak.
+4. Konpare ak relve labank/MonCash.
+5. Si jwenn: **Mark Verified**, dat reyèl, kapti opsyonèl.
+6. Si pa jwenn apre 5 jou ouvrab: **Failed** ak rezon.
+
+> **Kritik:** pa janm valide san prèv endepandan.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Pibliye nouvèl
+
+Wè [Gid Kontni](CONTENT_GUIDE.ht.md) pou pwosedi GitHub web (rekòmande). Yon editè web admin sou plan.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Pibliye yon alèt ijans
+
+1. `/admin/emergency` → **New Alert**.
+2. Tit nan 4 lang, kò, severite (`info`/`warning`/`critical`), kòmansman, fen.
+3. Sove.
+
+Alèt parèt imedyatman.
+
+> Doub alèt kritik atravè WhatsApp, radyo, opalè minisipal. Pòtal konplete, pa ranplase.
+
+Pou fini bonè: edite fen oswa klike **Deactivate**.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Jere ofisyèl
+
+`/admin/officials`. Nouvo: non, wòl, seksyon kominal, foto, WhatsApp, pwofil Vwa. Mete inaktif olye retire.
+
+Nan chak eleksyon, planifye 2 èdtan nan 7 jou apre envestiti.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Jere etablisman
+
+`/admin/facilities`. Kategori: lopital, lekòl, polis, ponpye, legliz, mache, gouvènman, lòt.
+
+GPS atravè telefòn oswa Google Maps (klik dwat → « Plis enfòmasyon sou kote sa »).
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Egzamine sijesyon
+
+`/admin/facility-suggestions`. Aksepte oswa rejte ak rezon. Netwaye chak semèn.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Rapò teren
+
+`/admin/field-reports`. Tip, kote, deskripsyon, foto, severite. Antre nan kat `/map`.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Manyèl gouvènans
+
+`/admin/handbook`. Lekti: tout admin dapre wòl. Edisyon: `superadmin` atravè `/admin/handbook/editor`. Lekti swiv — itil pou onboarding.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Revizyon odit finans
+
+`/admin/finance/audit-review`. Snapshot otomatik. Konpare mwa kouran/mwa anvan. Anomali → eskalade trezorye. Paj an lekti sèlman.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Wòl itilizatè ak aksè
+
+| Wòl | Ka |
+|---|---|
+| `user` | Soumèt demann, peye |
+| `admin` | Demann, peyman, ofisyèl/etablisman, nouvèl/alèt |
+| `superadmin` | Tout admin + handbook + kreye/dezaktive admin |
+
+Omwen **de `superadmin`** pa komin.
+
+Nouvo admin: `/admin/users` oswa Drizzle Studio. Pa janm kont pataje.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Dekonèksyon ak pasaj
+
+Fen pòs:
+1. Nòt nan **Open requests**.
+2. Mesaj Slack/WhatsApp ekip pwochen: ijans, peyman, alèt aktif.
+3. Avatar → **Logout**.
+4. Fèmen onglè (aparèy pataje).
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Rezolisyon pwoblèm
+
+| Pwoblèm | Aksyon |
+|---|---|
+| Modpas bliye | Reseti pa lidè IT |
+| Pa wè admin panel | Kont pa admin — mande superadmin |
+| Peyman valide pa erè | **Reverse Verification** + rezon |
+| Erè frap sou nouvèl/alèt | Re-edite MDX/alèt |
+| Sit pa disponib | `/api/health`, si non lidè IT |
+| Wè done yon lòt komin | **Ensidan kritik**: `security@haiticity.org` imedyatman |
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+[← Endèks dokimantasyon](README.ht.md) · [Mete yon Vil Anplas](TENANT_ONBOARDING.ht.md) · [Gid Kontni →](CONTENT_GUIDE.ht.md)

--- a/docs/ADMIN_MANUAL.md
+++ b/docs/ADMIN_MANUAL.md
@@ -1,0 +1,325 @@
+<!--
+Languages: English (this file) | Français (ADMIN_MANUAL.fr.md) | Kreyòl (ADMIN_MANUAL.ht.md) | Español (ADMIN_MANUAL.es.md)
+-->
+
+**Languages:** **English** · [Français](ADMIN_MANUAL.fr.md) · [Kreyòl Ayisyen](ADMIN_MANUAL.ht.md) · [Español](ADMIN_MANUAL.es.md)
+
+[← Docs index](README.md) · [Project README](../README.md) · [Glossary](GLOSSARY.md)
+
+---
+
+# Admin Manual
+
+A practical day-to-day guide for municipal staff using the admin panel. No technical background required.
+
+## Table of Contents
+
+- [Before you start](#before-you-start)
+- [Logging in](#logging-in)
+- [The dashboard](#the-dashboard)
+- [Service requests](#service-requests)
+- [Verifying payments](#verifying-payments)
+- [Publishing news](#publishing-news)
+- [Posting an emergency alert](#posting-an-emergency-alert)
+- [Managing officials](#managing-officials)
+- [Managing facilities](#managing-facilities)
+- [Reviewing facility suggestions](#reviewing-facility-suggestions)
+- [Field reports](#field-reports)
+- [Governance handbook](#governance-handbook)
+- [Finance audit review](#finance-audit-review)
+- [User roles and access](#user-roles-and-access)
+- [Logging out and shift handover](#logging-out-and-shift-handover)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Before you start
+
+You need:
+
+- A web browser (Chrome, Edge, Safari, Firefox).
+- Your admin email and password (given to you by your IT lead).
+- Internet access.
+
+Recommended:
+- A second screen or tab for taking notes.
+- Read the [Glossary](GLOSSARY.md) once.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Logging in
+
+1. Go to your commune's portal: `https://{your-subdomain}.portal.ht` (e.g. `https://jacmel.portal.ht`).
+2. Click **Login** (top right) or go directly to `/login`.
+3. Enter your email and password.
+4. You will land on the admin dashboard at `/admin`.
+
+If your password doesn't work, ask your IT lead to reset it. Never share your password.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## The dashboard
+
+The dashboard at `/admin` is your starting point each day. It shows:
+
+- **Open service requests** — issues residents have reported that need attention.
+- **Pending payments** — payments awaiting verification.
+- **Recent activity** — what other admins have done.
+- **Quick links** to every section of the panel.
+
+Get into the habit of opening the dashboard first thing in the morning.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Service requests
+
+Residents submit issues and service applications through the public `/report` form. They appear here.
+
+### Reading a request
+
+1. From the dashboard, click **Requests** or go to `/admin/requests`.
+2. The list shows: date, type (issue, certificate, permit…), status, and a one-line summary.
+3. Click a row to see the full detail at `/admin/requests/[id]`:
+   - Resident name and contact (if provided)
+   - Description, photo, GPS location
+   - Status history
+
+### Updating the status
+
+| Status | Meaning |
+|---|---|
+| **Open** | Just submitted, not yet looked at |
+| **In progress** | A staff member is working on it |
+| **Resolved** | The issue is fixed or the request fulfilled |
+| **Closed** | Resolved and acknowledged by the resident |
+| **Rejected** | Not actionable (out of scope, duplicate, malicious) — include a reason |
+
+Click **Update Status**, choose the new status, and add a short note describing what was done. The note is internal — residents do not see it (yet).
+
+### Best practices
+
+- Always update within **48 hours** of submission, even if just to acknowledge.
+- For complex issues, set **In progress** and update again when done.
+- For rejections, write a clear reason — this protects the commune later.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Verifying payments
+
+Today's payment flow is *manual reconciliation*: the resident is given a memo code, they pay via MonCash or wire transfer with that code as the reference, and you confirm receipt.
+
+### Workflow
+
+1. Go to `/admin/finance`.
+2. Filter by status **Pending Upload**.
+3. Open a payment to see:
+   - Memo code (e.g. `JAC-TAX-8821`)
+   - Amount
+   - Payment method (MonCash or wire)
+   - Resident contact info
+4. Cross-check with your commune's bank statement or MonCash statement.
+5. If you find a matching payment:
+   - Click **Mark Verified**.
+   - Enter the date the payment was actually received.
+   - (Optional) Upload a screenshot of the bank/MonCash entry.
+6. If you cannot find the payment after 5 business days:
+   - Mark **Failed** with reason "not received".
+
+### Why memo codes matter
+
+The memo code is the *only* way to know which resident a payment belongs to. If a resident forgot the code, ask for the date and amount and search the system manually.
+
+> **Critical:** never mark a payment as verified without independent proof in your bank or MonCash statement. This is your audit trail.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Publishing news
+
+News articles are published from MDX files in the repository. There are two paths:
+
+### Path A — GitHub web UI (no coding)
+
+This is the recommended way for content editors. See [Content Guide](CONTENT_GUIDE.md) for the full step-by-step.
+
+### Path B — Future admin UI
+
+A web-based editor is on the roadmap. Until then, content lives in version control to give you a permanent edit history.
+
+When the article is merged, it appears within minutes on the homepage and `/news` page. No deployment action required from you.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Posting an emergency alert
+
+Emergency alerts (hurricane, curfew, water cut, contaminated well) are stored in the database and shown prominently to all visitors of your tenant.
+
+1. Go to `/admin/emergency`.
+2. Click **New Alert**.
+3. Fill in:
+   - Title in all four languages (`{ en, fr, ht, es }`)
+   - Body text — keep it short and actionable
+   - Severity (`info` / `warning` / `critical`)
+   - Start time (defaults to now)
+   - End time (when the alert auto-disappears)
+4. Save.
+
+The alert appears immediately on every public page.
+
+> **Best practice:** for the most urgent alerts, also push the message via WhatsApp, radio, and city loudspeakers. The portal complements traditional channels — it does not replace them.
+
+To end an alert early, edit it and set the end time to the current moment, or click **Deactivate**.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Managing officials
+
+The officials directory at `/officials` shows your commune's elected officials publicly. Keep it accurate.
+
+1. Go to `/admin/officials` (or wherever your version of the panel exposes it).
+2. To add a new official: click **New**, fill in name, role (CASEC / ASEC / Mayor / Town Delegate), communal section (if applicable), photo URL, optional WhatsApp and Vwa profile.
+3. To update a term ending or stepping down, edit the record and update the dates.
+4. To remove someone (e.g. resigned), set them inactive rather than deleting — this preserves history.
+
+> **Tip:** at every election, schedule a 2-hour update session within 7 days of inauguration to refresh photos and contact info.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Managing facilities
+
+The facilities directory at `/directory` lists hospitals, schools, police stations, churches, markets, etc. on a map.
+
+1. Go to `/admin/facilities` (or your panel's equivalent).
+2. **New facility**: name, category, GPS latitude/longitude, address, phone.
+3. **Edit**: update phone numbers, hours, GPS as needed.
+4. **Categories**: hospital, school, police, fire, church, market, government, other.
+
+Tip: use a phone with GPS to capture coordinates on site, or use [Google Maps](https://maps.google.com) (right-click any point → "What's here?" → copy coordinates).
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Reviewing facility suggestions
+
+Residents can suggest corrections or new facilities through the directory. These flow into `facility_suggestions`.
+
+1. Go to `/admin/facility-suggestions` (or via the dashboard).
+2. Each suggestion shows: which facility, what was changed, who suggested (if signed in), when.
+3. Review and either:
+   - **Accept** — the change is applied to the live record.
+   - **Reject** — note a reason; the suggestion is archived.
+4. Try to clear new suggestions weekly.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Field reports
+
+Field reports are *staff-submitted* observations from the field (e.g. flooded street, market damage after a storm). Different from resident-submitted service requests.
+
+1. Go to `/admin/field-reports`.
+2. **New Report**: type, location, description, photo, severity.
+3. Reports feed into the issues map (`/map`) for residents and into your finance/works planning.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Governance handbook
+
+The handbook at `/admin/handbook` is your internal knowledge base — articles on procedures, finance, ethics, communications.
+
+- **Reading**: every admin can read articles permitted by their role.
+- **Editing**: only `superadmin` users can edit articles via `/admin/handbook/editor`.
+- **Read tracking**: the system records who has read each article — useful for new-staff onboarding.
+
+When you join the team, read the handbook front-to-back during your first week.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Finance audit review
+
+`/admin/finance/audit-review` shows audit snapshots: point-in-time captures of finance figures used to detect after-the-fact tampering.
+
+- Snapshots are taken automatically on a schedule (configurable).
+- Compare today's snapshot against last month's to spot anomalies.
+- If the totals do not match what you expect, escalate to your treasurer immediately.
+
+This page is read-only. You cannot delete or modify snapshots — that's the point.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## User roles and access
+
+| Role | Can do |
+|---|---|
+| `user` | Submit service requests, make payments — same as a resident |
+| `admin` | Read/update service requests, verify payments, manage officials/facilities, post news/alerts |
+| `superadmin` | Everything `admin` does, plus edit the handbook, create/disable other admin accounts |
+
+You should normally have **at least two `superadmin`s** so that one can recover access if the other is unavailable.
+
+To add a new admin user:
+1. Go to `/admin/users` (or via Drizzle Studio if not yet in the UI).
+2. **New User**: email, name, role.
+3. The new user receives an email with a temporary password (when email is configured).
+
+Never share an account between people. Every admin needs their own login.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Logging out and shift handover
+
+At the end of every shift:
+
+1. Note any unfinished work in the dashboard's **Open requests** view.
+2. Send a short Slack/WhatsApp note to the next shift summarising:
+   - High-priority requests still open
+   - Payments that need attention
+   - Any active emergency alerts
+3. Click your avatar (top right) → **Logout**.
+4. Close the browser tab — especially on shared devices.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Troubleshooting
+
+| Problem | What to do |
+|---|---|
+| "Forgot my password" | Ask your IT lead to reset it (they run a small command on the server) |
+| "I don't see the admin panel" | Your account is not an admin yet — ask a superadmin to upgrade your role |
+| "I marked a payment verified by mistake" | Open the payment, click **Reverse Verification**, leave a reason |
+| "I posted news/alert with a typo" | Edit the source MDX file (or alert record) and save again — changes are live within minutes |
+| "Site is down" | Check `https://{subdomain}.portal.ht/api/health`. If it returns an error, contact your IT lead. |
+| "I can see another commune's data" | This is a **critical security incident**. Email `security@haiticity.org` immediately and do not refresh. |
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+[← Docs index](README.md) · [Tenant Onboarding](TENANT_ONBOARDING.md) · [Content Guide →](CONTENT_GUIDE.md)

--- a/docs/ARCHITECTURE.es.md
+++ b/docs/ARCHITECTURE.es.md
@@ -1,0 +1,280 @@
+<!--
+Idiomas: English (ARCHITECTURE.md) | Français (ARCHITECTURE.fr.md) | Kreyòl (ARCHITECTURE.ht.md) | Español (este archivo)
+-->
+
+**Idiomas:** [English](ARCHITECTURE.md) · [Français](ARCHITECTURE.fr.md) · [Kreyòl Ayisyen](ARCHITECTURE.ht.md) · **Español**
+
+[← Índice de documentación](README.es.md) · [README del proyecto](../README.md) · [Glosario](GLOSSARY.es.md)
+
+---
+
+# Arquitectura
+
+Vista general en una página. Léala antes de [Notas Técnicas](technical-notes.md). Para los *porqués*: [ADR](adr/README.es.md).
+
+## Índice
+
+- [Diagrama del sistema](#diagrama-del-sistema)
+- [Diagrama del flujo de una petición](#diagrama-del-flujo-de-una-petición)
+- [Estructura del código](#estructura-del-código)
+- [Las seis reglas estrictas](#las-seis-reglas-estrictas)
+- [Frontend vs backend](#frontend-vs-backend)
+- [Flujo de datos](#flujo-de-datos)
+- [Multi-tenant](#multi-tenant)
+- [Internacionalización](#internacionalización)
+- [Sistema de contenido](#sistema-de-contenido)
+- [Autenticación y roles](#autenticación-y-roles)
+
+---
+
+## Diagrama del sistema
+
+```mermaid
+flowchart TD
+    User((Residente<br/>navegador))
+    DNS[Cloudflare DNS<br/>*.portal.ht]
+    Vercel[Vercel<br/>Next.js 15 + React 19]
+    Middleware[middleware.ts<br/>locale + tenant + auth]
+    SC[Server Components<br/>consulta BD filtrada por tenant_id]
+    DB[(Neon<br/>PostgreSQL 16)]
+    MDX[(Contenido MDX<br/>src/content/)]
+    Messages[(messages/*.json<br/>traducciones UI)]
+
+    User -->|jacmel.portal.ht| DNS
+    DNS --> Vercel
+    Vercel --> Middleware
+    Middleware --> SC
+    SC --> DB
+    SC --> MDX
+    SC --> Messages
+```
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Diagrama del flujo de una petición
+
+Visita a `https://jacmel.portal.ht/services/trash`:
+
+```mermaid
+sequenceDiagram
+    participant B as Navegador
+    participant V as Edge Vercel
+    participant M as middleware.ts
+    participant L as Layout (locale)
+    participant P as Página (services/trash)
+    participant D as Postgres (Neon)
+    participant F as Archivo MDX
+
+    B->>V: GET /services/trash<br/>Host: jacmel.portal.ht<br/>Cookie: NEXT_LOCALE=ht
+    V->>M: Reenvía petición
+    M->>M: Detecta locale (ht), redirige a /ht/services/trash<br/>Pone x-tenant-subdomain: jacmel<br/>Verifica auth (página pública)
+    M-->>B: 307 Redirect → /ht/services/trash
+    B->>V: GET /ht/services/trash
+    V->>L: Renderiza layout
+    L->>D: SELECT * FROM tenants WHERE subdomain='jacmel'
+    D-->>L: fila tenant
+    L->>P: Renderiza página
+    P->>F: Lee services/trash.ht.mdx<br/>(fallback a .mdx si falta)
+    F-->>P: Frontmatter + cuerpo
+    P-->>V: HTML
+    V-->>B: 200 OK + HTML
+```
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Estructura del código
+
+```
+HaitiCityPortal/
+├── src/
+│   ├── middleware.ts             ← corre antes de cada petición
+│   ├── auth.ts, auth.config.ts   ← NextAuth
+│   ├── app/
+│   │   ├── [locale]/
+│   │   │   ├── (public)/         ← acceso libre
+│   │   │   └── (protected)/      ← requiere sesión (admin)
+│   │   ├── actions/              ← server actions
+│   │   ├── api/                  ← rutas API
+│   │   ├── layout.tsx
+│   │   ├── error.tsx
+│   │   └── not-found.tsx         ← 404 (usa next/link, ver ADR)
+│   ├── components/
+│   ├── content/                  ← MDX
+│   ├── db/                       ← Drizzle, seed
+│   ├── features/
+│   ├── hooks/
+│   ├── i18n/                     ← next-intl
+│   ├── lib/
+│   └── utils/
+├── messages/                     ← strings UI (4 locales)
+├── docs/
+├── drizzle/                      ← migraciones
+├── tests/e2e/                    ← Playwright
+├── public/
+├── .github/workflows/            ← CI
+└── …
+```
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Las seis reglas estrictas
+
+No negociables.
+
+| # | Regla | Por qué |
+|---|---|---|
+| 1 | Toda tabla de entidad tiene `tenant_id`. Toda consulta filtra por él. | Aislamiento entre tenants. |
+| 2 | Todas las PKs son `uuid().defaultRandom()`. | Generación offline sin colisiones. [ADR-0002](adr/0002-uuid-primary-keys.es.md). |
+| 3 | Sin strings UI hardcodeados. UI en `messages/*.json`; prosa en `src/content/*.mdx`. | Corrección multilingüe. |
+| 4 | Todas las páginas bajo `src/app/[locale]/`. | Prefijo de locale obligatorio. |
+| 5 | `x-tenant-subdomain` la pone solo el middleware — nunca confiar desde el cliente. | Evita suplantación de tenant. |
+| 6 | `Link`, `redirect`, `useRouter` desde `@/i18n/navigation` (excepto `not-found.tsx`). | Prefijos automáticos, tipos seguros. |
+
+También en [`copilot-instructions.md`](../copilot-instructions.md).
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Frontend vs backend
+
+En Next.js, frontend y backend **comparten la misma base de código**, pero corren en lugares distintos.
+
+| Código | Corre en | Función |
+|---|---|---|
+| `src/components/**/*.tsx` (sin `"use client"`) | Servidor | Componentes renderizados en server |
+| `src/components/**/*.tsx` (con `"use client"`) | Navegador | Componentes interactivos |
+| `src/app/[locale]/**/page.tsx` (default) | Servidor | Páginas (Server Components) |
+| `src/app/actions/**/*.ts` | Servidor | Envíos de formulario |
+| `src/app/api/**/route.ts` | Servidor | Endpoints API |
+| `src/middleware.ts` | Edge | Locale + tenant + auth |
+| `src/db/**` | Solo servidor | Drizzle |
+| `src/lib/**` | Servidor (mayormente) | Helpers |
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Flujo de datos
+
+```mermaid
+flowchart LR
+    Resident([Residente])
+    Form[/Formulario /report/]
+    Action[Server Action]
+    Validate[Validación Zod]
+    Insert[(Postgres<br/>service_requests)]
+    Admin([Admin])
+    Dashboard[/Dashboard admin/]
+    Update[Actualizar estado]
+
+    Resident --> Form --> Action --> Validate --> Insert
+    Insert --> Dashboard
+    Admin --> Dashboard --> Update --> Insert
+```
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Multi-tenant
+
+```mermaid
+flowchart TD
+    subgraph DNS
+      WC[*.portal.ht]
+    end
+    subgraph App[Un solo despliegue Vercel]
+      MW[middleware.ts]
+      SC[Server Components]
+    end
+    subgraph DB[Una sola base Neon]
+      T[tenants]
+      U[users]
+      SR[service_requests]
+      Other[etc.]
+    end
+
+    WC -->|jacmel.portal.ht| MW
+    WC -->|cap.portal.ht| MW
+    MW -->|x-tenant-subdomain| SC
+    SC -->|WHERE tenant_id = ...| T
+    SC --> U
+    SC --> SR
+    SC --> Other
+```
+
+Una app. Una base. Muchas comunas. Datos separados lógicamente por `tenant_id`. [ADR-0001](adr/0001-multi-tenant-via-subdomain.es.md).
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Internacionalización
+
+Tres capas:
+
+| Capa | Ubicación | Ejemplo |
+|---|---|---|
+| Etiquetas UI | `messages/{locale}.json` | "Enviar", "Pagar" |
+| Prosa | `src/content/**/*.{locale}.mdx` | Descripciones de servicios |
+| Dinámico | Columnas JSONB `{en,fr,ht,es}` | Nombres editables |
+
+URLs con prefijo. Default: `ht`. Fallback silencioso al inglés.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Sistema de contenido
+
+`src/lib/content.tsx`:
+
+| Función | Uso |
+|---|---|
+| `loadContent(slug, locale)` | Cualquier MDX |
+| `loadNewsItems(locale, limit)` | Últimas N noticias (home) |
+| `loadAllNewsItems(locale)` | Índice de noticias |
+| `loadNewsItem(slug, locale)` | Detalle de noticia |
+| `getNewsSlugs()` | `generateStaticParams` |
+| `getNewsCount()` | Mostrar "Ver todas" condicionalmente |
+| `MarkdownRenderer` | Render Markdown estilizado |
+
+Memoización `React.cache` por `(slug, locale)`. [ADR-0003](adr/0003-mdx-content-vs-database.es.md).
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Autenticación y roles
+
+NextAuth v5 beta. `src/auth.config.ts` (Edge) + `src/auth.ts` (con adaptador Drizzle).
+
+Tres roles: `user`, `admin`, `superadmin`. Las rutas que contienen `/admin` están protegidas por el middleware.
+
+```mermaid
+flowchart LR
+    R([Petición /admin/*])
+    M[middleware.ts]
+    A{¿Sesión válida?}
+    L[/Página login/]
+    P[Página admin]
+
+    R --> M --> A
+    A -->|No| L
+    A -->|Sí| P
+```
+
+Chequeo por rol en Server Components / Server Actions vía `session.user.role`.
+
+[↑ Volver arriba](#índice)
+
+---
+
+[← Índice de documentación](README.es.md) · [Glosario](GLOSSARY.es.md) · [ADR →](adr/README.es.md)

--- a/docs/ARCHITECTURE.fr.md
+++ b/docs/ARCHITECTURE.fr.md
@@ -1,0 +1,280 @@
+<!--
+Langues : English (ARCHITECTURE.md) | Français (ce fichier) | Kreyòl (ARCHITECTURE.ht.md) | Español (ARCHITECTURE.es.md)
+-->
+
+**Langues :** [English](ARCHITECTURE.md) · **Français** · [Kreyòl Ayisyen](ARCHITECTURE.ht.md) · [Español](ARCHITECTURE.es.md)
+
+[← Index de la documentation](README.fr.md) · [README du projet](../README.md) · [Glossaire](GLOSSARY.fr.md)
+
+---
+
+# Architecture
+
+Vue d'ensemble en une page. À lire avant [Notes techniques](technical-notes.md). Pour le *pourquoi*, voir [ADR](adr/README.fr.md).
+
+## Sommaire
+
+- [Diagramme système](#diagramme-système)
+- [Diagramme du flux d'une requête](#diagramme-du-flux-dune-requête)
+- [Organisation du code](#organisation-du-code)
+- [Les six règles strictes](#les-six-règles-strictes)
+- [Frontend vs backend](#frontend-vs-backend)
+- [Flux de données](#flux-de-données)
+- [Multi-tenant](#multi-tenant)
+- [Internationalisation](#internationalisation)
+- [Système de contenu](#système-de-contenu)
+- [Authentification et rôles](#authentification-et-rôles)
+
+---
+
+## Diagramme système
+
+```mermaid
+flowchart TD
+    User((Résident<br/>navigateur))
+    DNS[Cloudflare DNS<br/>*.portal.ht]
+    Vercel[Vercel<br/>Next.js 15 + React 19]
+    Middleware[middleware.ts<br/>locale + tenant + auth]
+    SC[Server Components<br/>requêtes DB filtrées par tenant_id]
+    DB[(Neon<br/>PostgreSQL 16)]
+    MDX[(Contenu MDX<br/>src/content/)]
+    Messages[(messages/*.json<br/>traductions UI)]
+
+    User -->|jacmel.portal.ht| DNS
+    DNS --> Vercel
+    Vercel --> Middleware
+    Middleware --> SC
+    SC --> DB
+    SC --> MDX
+    SC --> Messages
+```
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Diagramme du flux d'une requête
+
+Visite de `https://jacmel.portal.ht/services/trash` :
+
+```mermaid
+sequenceDiagram
+    participant B as Navigateur
+    participant V as Edge Vercel
+    participant M as middleware.ts
+    participant L as Layout (locale)
+    participant P as Page (services/trash)
+    participant D as Postgres (Neon)
+    participant F as Fichier MDX
+
+    B->>V: GET /services/trash<br/>Host: jacmel.portal.ht<br/>Cookie: NEXT_LOCALE=ht
+    V->>M: Transmet la requête
+    M->>M: Détecte locale (ht), redirige vers /ht/services/trash<br/>Pose x-tenant-subdomain: jacmel<br/>Vérifie auth (publique)
+    M-->>B: 307 Redirect → /ht/services/trash
+    B->>V: GET /ht/services/trash
+    V->>L: Rend layout
+    L->>D: SELECT * FROM tenants WHERE subdomain='jacmel'
+    D-->>L: ligne tenant
+    L->>P: Rend page
+    P->>F: Lit services/trash.ht.mdx<br/>(repli sur .mdx si absent)
+    F-->>P: Frontmatter + corps
+    P-->>V: HTML
+    V-->>B: 200 OK + HTML
+```
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Organisation du code
+
+```
+HaitiCityPortal/
+├── src/
+│   ├── middleware.ts             ← s'exécute avant chaque requête
+│   ├── auth.ts, auth.config.ts   ← NextAuth
+│   ├── app/
+│   │   ├── [locale]/
+│   │   │   ├── (public)/         ← accès libre
+│   │   │   └── (protected)/      ← session requise (admin)
+│   │   ├── actions/              ← server actions
+│   │   ├── api/                  ← routes API
+│   │   ├── layout.tsx            ← layout racine
+│   │   ├── error.tsx             ← boundary d'erreur global
+│   │   └── not-found.tsx         ← 404 (utilise next/link, voir ADR)
+│   ├── components/               ← UI réutilisable
+│   ├── content/                  ← contenu MDX
+│   ├── db/                       ← schéma Drizzle, client, seeds
+│   ├── features/                 ← composants groupés par feature
+│   ├── hooks/                    ← hooks React
+│   ├── i18n/                     ← next-intl
+│   ├── lib/                      ← utilitaires
+│   └── utils/                    ← validateurs
+├── messages/                     ← chaînes UI (4 locales)
+├── docs/
+├── drizzle/                      ← migrations générées
+├── tests/e2e/                    ← Playwright
+├── public/
+├── .github/workflows/            ← CI
+└── …
+```
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Les six règles strictes
+
+Non négociables.
+
+| # | Règle | Pourquoi |
+|---|---|---|
+| 1 | Chaque table d'entité a `tenant_id`. Chaque requête filtre dessus. | Isolation entre tenants. |
+| 2 | Toutes les PKs sont `uuid().defaultRandom()`. | Génération hors-ligne sans collision. [ADR-0002](adr/0002-uuid-primary-keys.fr.md). |
+| 3 | Aucune chaîne UI codée en dur. UI dans `messages/*.json` ; prose dans `src/content/*.mdx`. | Correction multilingue. |
+| 4 | Toutes les pages sous `src/app/[locale]/`. | Préfixe locale obligatoire. |
+| 5 | `x-tenant-subdomain` est posé par le middleware uniquement — jamais cru depuis le client. | Empêche l'usurpation de tenant. |
+| 6 | `Link`, `redirect`, `useRouter` depuis `@/i18n/navigation` (sauf `not-found.tsx`). | Préfixes automatiques, types sûrs. |
+
+Aussi documentées dans [`copilot-instructions.md`](../copilot-instructions.md).
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Frontend vs backend
+
+Sous Next.js, le frontend et le backend **partagent le même code**, mais s'exécutent à des endroits différents.
+
+| Code | S'exécute sur | Rôle |
+|---|---|---|
+| `src/components/**/*.tsx` (sans `"use client"`) | Serveur | Composants rendus côté serveur |
+| `src/components/**/*.tsx` (avec `"use client"`) | Navigateur | Composants interactifs (cartes, formulaires) |
+| `src/app/[locale]/**/page.tsx` (par défaut) | Serveur | Pages (Server Components) |
+| `src/app/actions/**/*.ts` | Serveur | Soumissions de formulaires |
+| `src/app/api/**/route.ts` | Serveur | Endpoints API |
+| `src/middleware.ts` | Edge | Locale + tenant + auth |
+| `src/db/**` | Serveur uniquement | Drizzle |
+| `src/lib/**` | Serveur (essentiellement) | Helpers |
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Flux de données
+
+```mermaid
+flowchart LR
+    Resident([Résident])
+    Form[/Formulaire /report/]
+    Action[Server Action]
+    Validate[Validation Zod]
+    Insert[(Postgres<br/>service_requests)]
+    Admin([Admin])
+    Dashboard[/Dashboard admin/]
+    Update[Mise à jour statut]
+
+    Resident --> Form --> Action --> Validate --> Insert
+    Insert --> Dashboard
+    Admin --> Dashboard --> Update --> Insert
+```
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Multi-tenant
+
+```mermaid
+flowchart TD
+    subgraph DNS
+      WC[*.portal.ht]
+    end
+    subgraph App[Un seul déploiement Vercel]
+      MW[middleware.ts]
+      SC[Server Components]
+    end
+    subgraph DB[Une seule base Neon]
+      T[tenants]
+      U[users]
+      SR[service_requests]
+      Other[etc.]
+    end
+
+    WC -->|jacmel.portal.ht| MW
+    WC -->|cap.portal.ht| MW
+    MW -->|x-tenant-subdomain| SC
+    SC -->|WHERE tenant_id = ...| T
+    SC --> U
+    SC --> SR
+    SC --> Other
+```
+
+Une application. Une base. Plusieurs communes. Données séparées logiquement par `tenant_id`. Voir [ADR-0001](adr/0001-multi-tenant-via-subdomain.fr.md).
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Internationalisation
+
+Trois couches :
+
+| Couche | Emplacement | Exemple |
+|---|---|---|
+| Étiquettes UI | `messages/{locale}.json` | « Soumettre », « Payer » |
+| Prose | `src/content/**/*.{locale}.mdx` | Description de services, articles |
+| Dynamique | Colonnes JSONB `{en,fr,ht,es}` | Noms de services modifiables |
+
+URLs préfixées. Locale par défaut : `ht`. Repli silencieux sur l'anglais.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Système de contenu
+
+`src/lib/content.tsx` :
+
+| Fonction | Usage |
+|---|---|
+| `loadContent(slug, locale)` | Tout fichier MDX |
+| `loadNewsItems(locale, limit)` | N derniers articles (accueil) |
+| `loadAllNewsItems(locale)` | Index actualités |
+| `loadNewsItem(slug, locale)` | Détail article |
+| `getNewsSlugs()` | `generateStaticParams` |
+| `getNewsCount()` | Lien « Voir tout » conditionnel |
+| `MarkdownRenderer` | Rendu Markdown stylé |
+
+Mémoïsation `React.cache` par `(slug, locale)`. Voir [ADR-0003](adr/0003-mdx-content-vs-database.fr.md).
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Authentification et rôles
+
+NextAuth v5 beta. `src/auth.config.ts` (Edge) + `src/auth.ts` (avec adaptateur Drizzle).
+
+Trois rôles : `user`, `admin`, `superadmin`. Les chemins contenant `/admin` sont protégés par le middleware.
+
+```mermaid
+flowchart LR
+    R([Requête /admin/*])
+    M[middleware.ts]
+    A{Session valide ?}
+    L[/Page login/]
+    P[Page admin]
+
+    R --> M --> A
+    A -->|Non| L
+    A -->|Oui| P
+```
+
+Vérifications par rôle dans Server Components / Server Actions via `session.user.role`.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+[← Index de la documentation](README.fr.md) · [Glossaire](GLOSSARY.fr.md) · [ADR →](adr/README.fr.md)

--- a/docs/ARCHITECTURE.ht.md
+++ b/docs/ARCHITECTURE.ht.md
@@ -1,0 +1,280 @@
+<!--
+Lang yo: English (ARCHITECTURE.md) | Français (ARCHITECTURE.fr.md) | Kreyòl (fichye sa a) | Español (ARCHITECTURE.es.md)
+-->
+
+**Lang yo:** [English](ARCHITECTURE.md) · [Français](ARCHITECTURE.fr.md) · **Kreyòl Ayisyen** · [Español](ARCHITECTURE.es.md)
+
+[← Endèks dokimantasyon](README.ht.md) · [README pwojè a](../README.md) · [Glosè](GLOSSARY.ht.md)
+
+---
+
+# Achitekti
+
+Apèsi achitekti sou yon paj. Li sa anvan [Nòt Teknik](technical-notes.md). Pou poukisa: [ADR](adr/README.ht.md).
+
+## Tablo Kontni
+
+- [Dyagram sistèm](#dyagram-sistèm)
+- [Dyagram flo yon rekèt](#dyagram-flo-yon-rekèt)
+- [Estrikti kòd la](#estrikti-kòd-la)
+- [Sis règ strik yo](#sis-règ-strik-yo)
+- [Frontend vs backend](#frontend-vs-backend)
+- [Flo done](#flo-done)
+- [Milti-tenant](#milti-tenant)
+- [Entènasyonalizasyon](#entènasyonalizasyon)
+- [Sistèm kontni](#sistèm-kontni)
+- [Otantifikasyon ak wòl](#otantifikasyon-ak-wòl)
+
+---
+
+## Dyagram sistèm
+
+```mermaid
+flowchart TD
+    User((Rezidan<br/>navigatè))
+    DNS[Cloudflare DNS<br/>*.portal.ht]
+    Vercel[Vercel<br/>Next.js 15 + React 19]
+    Middleware[middleware.ts<br/>lokal + tenant + auth]
+    SC[Server Components<br/>rekèt BD filtre pa tenant_id]
+    DB[(Neon<br/>PostgreSQL 16)]
+    MDX[(Kontni MDX<br/>src/content/)]
+    Messages[(messages/*.json<br/>tradiksyon UI)]
+
+    User -->|jacmel.portal.ht| DNS
+    DNS --> Vercel
+    Vercel --> Middleware
+    Middleware --> SC
+    SC --> DB
+    SC --> MDX
+    SC --> Messages
+```
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Dyagram flo yon rekèt
+
+Vizit `https://jacmel.portal.ht/services/trash`:
+
+```mermaid
+sequenceDiagram
+    participant B as Navigatè
+    participant V as Edge Vercel
+    participant M as middleware.ts
+    participant L as Layout (lokal)
+    participant P as Paj (services/trash)
+    participant D as Postgres (Neon)
+    participant F as Fichye MDX
+
+    B->>V: GET /services/trash<br/>Host: jacmel.portal.ht<br/>Cookie: NEXT_LOCALE=ht
+    V->>M: Voye rekèt
+    M->>M: Detekte lokal (ht), redirije /ht/services/trash<br/>Mete x-tenant-subdomain: jacmel<br/>Verifye auth (paj piblik)
+    M-->>B: 307 Redirect → /ht/services/trash
+    B->>V: GET /ht/services/trash
+    V->>L: Rann layout
+    L->>D: SELECT * FROM tenants WHERE subdomain='jacmel'
+    D-->>L: liy tenant
+    L->>P: Rann paj
+    P->>F: Li services/trash.ht.mdx<br/>(sekou sou .mdx si absan)
+    F-->>P: Frontmatter + kò
+    P-->>V: HTML
+    V-->>B: 200 OK + HTML
+```
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Estrikti kòd la
+
+```
+HaitiCityPortal/
+├── src/
+│   ├── middleware.ts             ← mache anvan chak rekèt
+│   ├── auth.ts, auth.config.ts   ← NextAuth
+│   ├── app/
+│   │   ├── [locale]/
+│   │   │   ├── (public)/         ← aksè lib
+│   │   │   └── (protected)/      ← bezwen sesyon (admin)
+│   │   ├── actions/              ← server actions
+│   │   ├── api/                  ← woutin API
+│   │   ├── layout.tsx
+│   │   ├── error.tsx
+│   │   └── not-found.tsx         ← 404 (itilize next/link, wè ADR)
+│   ├── components/
+│   ├── content/                  ← MDX
+│   ├── db/                       ← Drizzle, seed
+│   ├── features/
+│   ├── hooks/
+│   ├── i18n/                     ← next-intl
+│   ├── lib/
+│   └── utils/
+├── messages/                     ← chèn UI (4 lokal)
+├── docs/
+├── drizzle/                      ← migrasyon
+├── tests/e2e/                    ← Playwright
+├── public/
+├── .github/workflows/            ← CI
+└── …
+```
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Sis règ strik yo
+
+Pa negosye.
+
+| # | Règ | Poukisa |
+|---|---|---|
+| 1 | Chak tab antite gen `tenant_id`. Chak rekèt filtre dessus. | Izolasyon ant tenant. |
+| 2 | Tout PK se `uuid().defaultRandom()`. | Jenerasyon ofliy san kolizyon. [ADR-0002](adr/0002-uuid-primary-keys.ht.md). |
+| 3 | Pa gen chèn UI ki ekri an dur. UI nan `messages/*.json` ; prose nan `src/content/*.mdx`. | Korèksyon multilang. |
+| 4 | Tout paj anba `src/app/[locale]/`. | Prefiks lokal obligatwa. |
+| 5 | `x-tenant-subdomain` mete pa middleware sèlman — pa janm fè konfyans li sou kliyan. | Anpeche pretansyon tenant. |
+| 6 | `Link`, `redirect`, `useRouter` soti nan `@/i18n/navigation` (sof `not-found.tsx`). | Prefiks otomatik, tip an sekirite. |
+
+Tou nan [`copilot-instructions.md`](../copilot-instructions.md).
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Frontend vs backend
+
+Anba Next.js, frontend ak backend **pataje menm kòd la**, men yo mache nan kote diferan.
+
+| Kòd | Mache sou | Wòl |
+|---|---|---|
+| `src/components/**/*.tsx` (san `"use client"`) | Sèvè | Konpozan rann sèvè |
+| `src/components/**/*.tsx` (ak `"use client"`) | Navigatè | Konpozan entèraktif |
+| `src/app/[locale]/**/page.tsx` (default) | Sèvè | Paj (Server Components) |
+| `src/app/actions/**/*.ts` | Sèvè | Soumisyon fòm |
+| `src/app/api/**/route.ts` | Sèvè | Pwen API |
+| `src/middleware.ts` | Edge | Lokal + tenant + auth |
+| `src/db/**` | Sèvè sèlman | Drizzle |
+| `src/lib/**` | Sèvè (sitou) | Helpers |
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Flo done
+
+```mermaid
+flowchart LR
+    Resident([Rezidan])
+    Form[/Fòm /report/]
+    Action[Server Action]
+    Validate[Validasyon Zod]
+    Insert[(Postgres<br/>service_requests)]
+    Admin([Admin])
+    Dashboard[/Tablobò admin/]
+    Update[Met estati ajou]
+
+    Resident --> Form --> Action --> Validate --> Insert
+    Insert --> Dashboard
+    Admin --> Dashboard --> Update --> Insert
+```
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Milti-tenant
+
+```mermaid
+flowchart TD
+    subgraph DNS
+      WC[*.portal.ht]
+    end
+    subgraph App[Yon sèl deplwaman Vercel]
+      MW[middleware.ts]
+      SC[Server Components]
+    end
+    subgraph DB[Yon sèl baz Neon]
+      T[tenants]
+      U[users]
+      SR[service_requests]
+      Other[etc.]
+    end
+
+    WC -->|jacmel.portal.ht| MW
+    WC -->|cap.portal.ht| MW
+    MW -->|x-tenant-subdomain| SC
+    SC -->|WHERE tenant_id = ...| T
+    SC --> U
+    SC --> SR
+    SC --> Other
+```
+
+Yon aplikasyon. Yon baz. Plizyè komin. Done separe lojikman pa `tenant_id`. [ADR-0001](adr/0001-multi-tenant-via-subdomain.ht.md).
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Entènasyonalizasyon
+
+Twa kouch:
+
+| Kouch | Kote | Egzanp |
+|---|---|---|
+| Etikèt UI | `messages/{locale}.json` | « Soumèt », « Peye » |
+| Prose | `src/content/**/*.{locale}.mdx` | Deskripsyon sèvis, atik |
+| Dinamik | Kolòn JSONB `{en,fr,ht,es}` | Non sèvis editab |
+
+URL prefiks. Default: `ht`. Sekou silansye sou anglè.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Sistèm kontni
+
+`src/lib/content.tsx`:
+
+| Fonksyon | Itilizasyon |
+|---|---|
+| `loadContent(slug, locale)` | Nenpòt fichye MDX |
+| `loadNewsItems(locale, limit)` | N dènye atik (akèy) |
+| `loadAllNewsItems(locale)` | Endèks nouvèl |
+| `loadNewsItem(slug, locale)` | Detay atik |
+| `getNewsSlugs()` | `generateStaticParams` |
+| `getNewsCount()` | Lyen « Wè Tout » kondisyonèl |
+| `MarkdownRenderer` | Rann Markdown style |
+
+Memoizasyon `React.cache` pa `(slug, locale)`. [ADR-0003](adr/0003-mdx-content-vs-database.ht.md).
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Otantifikasyon ak wòl
+
+NextAuth v5 beta. `src/auth.config.ts` (Edge) + `src/auth.ts` (ak adaptè Drizzle).
+
+Twa wòl: `user`, `admin`, `superadmin`. Chemen ki gen `/admin` pwoteje pa middleware.
+
+```mermaid
+flowchart LR
+    R([Rekèt /admin/*])
+    M[middleware.ts]
+    A{Sesyon valid?}
+    L[/Paj login/]
+    P[Paj admin]
+
+    R --> M --> A
+    A -->|Non| L
+    A -->|Wi| P
+```
+
+Verifikasyon pa wòl nan Server Components / Server Actions atravè `session.user.role`.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+[← Endèks dokimantasyon](README.ht.md) · [Glosè](GLOSSARY.ht.md) · [ADR →](adr/README.ht.md)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,326 @@
+<!--
+Languages: English (this file) | Français (ARCHITECTURE.fr.md) | Kreyòl (ARCHITECTURE.ht.md) | Español (ARCHITECTURE.es.md)
+-->
+
+**Languages:** **English** · [Français](ARCHITECTURE.fr.md) · [Kreyòl Ayisyen](ARCHITECTURE.ht.md) · [Español](ARCHITECTURE.es.md)
+
+[← Docs index](README.md) · [Project README](../README.md) · [Glossary](GLOSSARY.md)
+
+---
+
+# Architecture
+
+A one-page architecture overview. Read this before diving into [Technical Notes](technical-notes.md). For the *why* behind each decision, see [Architecture Decision Records](adr/README.md).
+
+## Table of Contents
+
+- [System diagram](#system-diagram)
+- [Request flow diagram](#request-flow-diagram)
+- [Codebase layout](#codebase-layout)
+- [The six hard rules](#the-six-hard-rules)
+- [Frontend vs backend](#frontend-vs-backend)
+- [Data flow](#data-flow)
+- [Multi-tenancy](#multi-tenancy)
+- [Internationalization](#internationalization)
+- [Content system](#content-system)
+- [Authentication and roles](#authentication-and-roles)
+
+---
+
+## System diagram
+
+```mermaid
+flowchart TD
+    User((Resident<br/>browser))
+    DNS[Cloudflare DNS<br/>*.portal.ht]
+    Vercel[Vercel<br/>Next.js 15 + React 19]
+    Middleware[middleware.ts<br/>locale + tenant + auth guard]
+    SC[Server Components<br/>read DB scoped by tenant_id]
+    DB[(Neon<br/>PostgreSQL 16)]
+    MDX[(MDX content<br/>src/content/)]
+    Messages[(messages/*.json<br/>UI translations)]
+
+    User -->|jacmel.portal.ht| DNS
+    DNS --> Vercel
+    Vercel --> Middleware
+    Middleware --> SC
+    SC --> DB
+    SC --> MDX
+    SC --> Messages
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Request flow diagram
+
+What happens when a resident visits `https://jacmel.portal.ht/services/trash`:
+
+```mermaid
+sequenceDiagram
+    participant B as Browser
+    participant V as Vercel edge
+    participant M as middleware.ts
+    participant L as Layout (locale)
+    participant P as Page (services/trash)
+    participant D as Postgres (Neon)
+    participant F as MDX file
+
+    B->>V: GET /services/trash<br/>Host: jacmel.portal.ht<br/>Cookie: NEXT_LOCALE=ht
+    V->>M: Forward request
+    M->>M: Detect locale (ht), redirect to /ht/services/trash<br/>Inject x-tenant-subdomain: jacmel<br/>Check auth (not required, public route)
+    M-->>B: 307 Redirect → /ht/services/trash
+    B->>V: GET /ht/services/trash
+    V->>L: Render layout
+    L->>D: SELECT * FROM tenants WHERE subdomain='jacmel'
+    D-->>L: tenant row
+    L->>P: Render page
+    P->>F: Read services/trash.ht.mdx<br/>(falls back to .mdx if missing)
+    F-->>P: Frontmatter + body
+    P-->>V: HTML
+    V-->>B: 200 OK + HTML
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Codebase layout
+
+```
+HaitiCityPortal/
+├── src/
+│   ├── middleware.ts             ← runs before every request: locale, tenant, auth
+│   ├── auth.ts, auth.config.ts   ← NextAuth setup
+│   ├── app/
+│   │   ├── [locale]/
+│   │   │   ├── (public)/         ← anyone can visit
+│   │   │   └── (protected)/      ← session required (admin)
+│   │   ├── actions/              ← server actions (form submissions)
+│   │   ├── api/                  ← API routes (/health, /events/ics, etc.)
+│   │   ├── layout.tsx            ← root layout
+│   │   ├── error.tsx             ← global error boundary
+│   │   └── not-found.tsx         ← 404 page (uses next/link, see ADR-0006)
+│   ├── components/               ← reusable UI: nav, forms, maps, payments…
+│   ├── content/                  ← MDX prose content (services, news, legal)
+│   ├── db/
+│   │   ├── schema.ts             ← Drizzle schema (source of truth)
+│   │   ├── index.ts              ← Drizzle client
+│   │   ├── seed.ts               ← demo seeder (localhost)
+│   │   └── seed.production.ts    ← production seeder (env-vars driven)
+│   ├── features/                 ← feature-grouped components (auth, incidents, reports)
+│   ├── hooks/                    ← React hooks
+│   ├── i18n/                     ← next-intl routing/navigation/request
+│   ├── lib/                      ← utilities (tenants, content, cn helper)
+│   └── utils/                    ← input validators
+├── messages/
+│   ├── en.json, fr.json, ht.json, es.json  ← UI strings only
+├── docs/
+├── drizzle/                      ← generated migrations
+├── tests/e2e/                    ← Playwright smoke tests
+├── public/                       ← static files served as-is
+├── .github/workflows/            ← CI: lint, typecheck, build, db-check, e2e
+├── package.json
+├── next.config.ts
+├── drizzle.config.ts
+├── playwright.config.ts
+└── tsconfig.json
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## The six hard rules
+
+These rules are non-negotiable. Violating them creates security, correctness, or i18n bugs.
+
+| # | Rule | Why |
+|---|---|---|
+| 1 | Every entity table has `tenant_id`. Every query filters by it. | Cross-tenant data isolation. |
+| 2 | All primary keys are `uuid().defaultRandom()`. | Offline ID generation, no collisions. See [ADR-0002](adr/0002-uuid-primary-keys.md). |
+| 3 | No hardcoded user-visible strings. UI in `messages/*.json`; prose in `src/content/*.mdx`. | Multilingual correctness; translators don't need to read code. |
+| 4 | All pages live under `src/app/[locale]/`. | Locale prefix is mandatory in URLs. |
+| 5 | `x-tenant-subdomain` is set by middleware only — never trust it from client requests. | Prevents tenant impersonation. |
+| 6 | Import `Link`, `redirect`, `useRouter` from `@/i18n/navigation`, NOT from `next/link`/`next/navigation`. (Exception: `src/app/not-found.tsx`.) | Locale prefixes are added automatically; type-safe routes. |
+
+These are also documented in [`copilot-instructions.md`](../copilot-instructions.md).
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Frontend vs backend
+
+In Next.js, frontend and backend live **in the same codebase**, but they run in different places.
+
+| Code lives in | Runs on | What it does |
+|---|---|---|
+| `src/components/**/*.tsx` (no `"use client"`) | Server | Page components rendered server-side |
+| `src/components/**/*.tsx` (with `"use client"`) | Browser | Interactive widgets (maps, forms with state) |
+| `src/app/[locale]/**/page.tsx` (default) | Server | Pages (Server Components by default) |
+| `src/app/actions/**/*.ts` | Server | Form submissions and mutations |
+| `src/app/api/**/route.ts` | Server | API endpoints (JSON, GeoJSON, ICS) |
+| `src/middleware.ts` | Edge runtime | Locale + tenant + auth guard |
+| `src/db/**` | Server only | Database access via Drizzle |
+| `src/lib/**` | Server (mostly) | Helpers (`getTenantBySubdomain`, content loaders) |
+
+A user opening `https://jacmel.portal.ht/services/trash` in their browser actually sees:
+
+1. HTML rendered on the server
+2. A small client-side hydration bundle for interactivity
+3. Anything marked `"use client"` is then run in the browser
+
+If you have only ever seen separate `frontend/` and `backend/` folders before, this can feel unfamiliar. It's idiomatic for Next.js — see [ADR-0004](adr/README.md).
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Data flow
+
+```mermaid
+flowchart LR
+    Resident([Resident])
+    Form[/Form on /report page/]
+    Action[Server Action<br/>src/app/actions/]
+    Validate[Zod validate]
+    Insert[(Postgres<br/>service_requests)]
+    Admin([Admin])
+    Dashboard[/Admin dashboard/]
+    Update[Status update<br/>via Server Action]
+
+    Resident --> Form --> Action --> Validate --> Insert
+    Insert --> Dashboard
+    Admin --> Dashboard --> Update --> Insert
+```
+
+Reads are even simpler:
+
+```mermaid
+flowchart LR
+    Browser([Browser])
+    Page[Server Component]
+    Tenant{getTenantBySubdomain}
+    Query[(Postgres<br/>filtered by tenant_id)]
+    HTML[/HTML/]
+
+    Browser --> Page --> Tenant --> Query --> Page --> HTML --> Browser
+```
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Multi-tenancy
+
+```mermaid
+flowchart TD
+    subgraph DNS
+      WC[*.portal.ht]
+    end
+    subgraph App[Single Vercel deployment]
+      MW[middleware.ts<br/>extract subdomain]
+      SC[Server Components]
+    end
+    subgraph DB[Single Neon database]
+      T[tenants]
+      U[users]
+      SR[service_requests]
+      P[payment_records]
+      O[officials]
+      F[facilities]
+      Other[etc.]
+    end
+
+    WC -->|jacmel.portal.ht| MW
+    WC -->|cap.portal.ht| MW
+    WC -->|petionville.portal.ht| MW
+    MW -->|x-tenant-subdomain header| SC
+    SC -->|WHERE tenant_id = ...| T
+    SC --> U
+    SC --> SR
+    SC --> P
+    SC --> O
+    SC --> F
+    SC --> Other
+```
+
+One application. One database. Many communes. Data is **logically separated by `tenant_id`** on every row, enforced at the application layer.
+
+For the rationale, see [ADR-0001](adr/0001-multi-tenant-via-subdomain.md).
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Internationalization
+
+Three layers of translatable content:
+
+| Layer | Location | Example |
+|---|---|---|
+| UI labels | `messages/{locale}.json` | "Submit", "Pay now", "Hospitals" |
+| Prose | `src/content/**/*.{locale}.mdx` | Service descriptions, news articles |
+| Dynamic | Database JSONB columns `{en,fr,ht,es}` | Service names that admins can edit |
+
+URLs are locale-prefixed. The default locale is `ht` (Haitian Creole). The middleware redirects bare paths (`/services` → `/ht/services`).
+
+If a translation file is missing, the system falls back to English silently — never breaks the page.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Content system
+
+`src/lib/content.tsx` exposes:
+
+| Function | Used for |
+|---|---|
+| `loadContent(slug, locale)` | Any MDX file (services, legal, about) |
+| `loadNewsItems(locale, limit)` | Latest N news (homepage) |
+| `loadAllNewsItems(locale)` | News index page |
+| `loadNewsItem(slug, locale)` | News detail page |
+| `getNewsSlugs()` | `generateStaticParams` for news pages |
+| `getNewsCount()` | Show "View All" link conditionally |
+| `MarkdownRenderer` | Render markdown body with consistent Tailwind styles |
+
+All loaders are memoised with `React.cache` so the same `(slug, locale)` is read once per request.
+
+For the choice to use MDX over a CMS, see [ADR-0003](adr/0003-mdx-content-vs-database.md).
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Authentication and roles
+
+NextAuth v5 (beta). Configuration is split across two files:
+
+- `src/auth.config.ts` — Edge-safe (no DB imports). Used by middleware.
+- `src/auth.ts` — Full config with the Drizzle adapter.
+
+Three roles: `user`, `admin`, `superadmin`. Routes containing `/admin` are protected by middleware; unauthenticated requests are redirected to `/{locale}/login?callbackUrl=...`.
+
+```mermaid
+flowchart LR
+    R([Request to /admin/*])
+    M[middleware.ts]
+    A{Session valid?}
+    L[/Login page/]
+    P[Admin page]
+
+    R --> M --> A
+    A -->|No| L
+    A -->|Yes| P
+```
+
+Per-page role checks (e.g. only `superadmin` can edit handbook articles) are enforced inside Server Components and Server Actions by checking `session.user.role`.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+[← Docs index](README.md) · [Glossary](GLOSSARY.md) · [ADRs →](adr/README.md)

--- a/docs/CONTENT_GUIDE.es.md
+++ b/docs/CONTENT_GUIDE.es.md
@@ -1,0 +1,310 @@
+<!--
+Idiomas: English (CONTENT_GUIDE.md) | Français (CONTENT_GUIDE.fr.md) | Kreyòl (CONTENT_GUIDE.ht.md) | Español (este archivo)
+-->
+
+**Idiomas:** [English](CONTENT_GUIDE.md) · [Français](CONTENT_GUIDE.fr.md) · [Kreyòl Ayisyen](CONTENT_GUIDE.ht.md) · **Español**
+
+[← Índice de documentación](README.es.md) · [README del proyecto](../README.md) · [Glosario](GLOSSARY.es.md)
+
+---
+
+# Guía de Contenido
+
+Cómo traducir o editar contenido **sin instalar nada** — solo un navegador y una cuenta de GitHub. Para traductores, equipos de comunicaciones y cualquiera que quiera mejorar los textos del portal.
+
+## Índice
+
+- [Qué puede editar](#qué-puede-editar)
+- [Crear una cuenta de GitHub](#crear-una-cuenta-de-github)
+- [Editar un archivo en GitHub](#editar-un-archivo-en-github)
+- [Editar una etiqueta UI (`messages/*.json`)](#editar-una-etiqueta-ui-messagesjson)
+- [Traducir la descripción de un servicio](#traducir-la-descripción-de-un-servicio)
+- [Agregar una noticia](#agregar-una-noticia)
+- [Editar una página estática](#editar-una-página-estática)
+- [Bases de Markdown](#bases-de-markdown)
+- [Cheat sheet de frontmatter](#cheat-sheet-de-frontmatter)
+- [Errores frecuentes](#errores-frecuentes)
+- [Obtener ayuda](#obtener-ayuda)
+
+---
+
+## Qué puede editar
+
+Todo es texto. Tres lugares:
+
+| Tipo | Ubicación | Ejemplo |
+|---|---|---|
+| Etiquetas UI (textos cortos) | `messages/{locale}.json` | "Enviar", menú nav |
+| Servicios, noticias, páginas legales | `src/content/**/*.mdx` | Página servicio basura, noticia huracán |
+| Traducciones | Mismos archivos con sufijo `.fr.`, `.ht.`, `.es.` | `services/trash.es.mdx` |
+
+Todo pasa por la interfaz web de GitHub. Sin software a instalar.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Crear una cuenta de GitHub
+
+Si ya tiene una, sáltese.
+
+1. <https://github.com/signup>.
+2. Email, contraseña, usuario.
+3. Confirme el email.
+4. (Opcional) Foto y rol en la comuna.
+
+Listo. Plan gratis basta.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Editar un archivo en GitHub
+
+Cinco pasos para cualquier edición:
+
+1. Inicie sesión en <https://github.com>.
+2. Vaya al archivo (links abajo).
+3. Clic en el **icono de lápiz** arriba a la derecha.
+4. Edite en el navegador.
+5. Baje. Elija **Create a new branch for this commit and start a pull request** (por defecto). **Propose changes**.
+6. En la siguiente pantalla: **Create pull request**.
+
+Un mantenedor revisa y fusiona. Pocos minutos tras la fusión, su cambio está en vivo.
+
+Si no tiene acceso de escritura al repositorio principal, GitHub ofrecerá hacer un **fork** — acepte.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Editar una etiqueta UI (`messages/*.json`)
+
+Textos cortos: navbar, botones, formularios.
+
+| Idioma | Archivo |
+|---|---|
+| Inglés | [`messages/en.json`](https://github.com/haitiansintech/HaitiCityPortal/blob/main/messages/en.json) |
+| Francés | [`messages/fr.json`](https://github.com/haitiansintech/HaitiCityPortal/blob/main/messages/fr.json) |
+| Criollo haitiano | [`messages/ht.json`](https://github.com/haitiansintech/HaitiCityPortal/blob/main/messages/ht.json) |
+| Español | [`messages/es.json`](https://github.com/haitiansintech/HaitiCityPortal/blob/main/messages/es.json) |
+
+### Ejemplo: mejorar una traducción al español
+
+```json
+{
+  "Nav": {
+    "home": "Inicio",
+    "services": "Servicios",
+    "report": "Reportar",
+    "pay": "Pagar"
+  }
+}
+```
+
+Para cambiar "Reportar" a "Reportar un problema":
+
+1. Lápiz.
+2. Cambie el **valor** (a la derecha de los dos puntos, entre comillas).
+3. PR.
+
+> **Importante:** nunca cambie las **claves** (izquierda: `home`, `services`…). Solo cambian los **valores**.
+
+> **Importante:** cualquier nueva clave en `en.json` debe estar en los **cuatro** archivos. Si no, aparece `MISSING_MESSAGE`.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Traducir la descripción de un servicio
+
+Archivos MDX en [`src/content/services/`](https://github.com/haitiansintech/HaitiCityPortal/tree/main/src/content/services).
+
+Base: `{slug}.mdx` (inglés). Traducciones: `{slug}.fr.mdx`, `.ht.mdx`, `.es.mdx`.
+
+### Ejemplo: agregar versión en español para "Trash Collection"
+
+1. Abra el inglés: [`src/content/services/trash.mdx`](https://github.com/haitiansintech/HaitiCityPortal/blob/main/src/content/services/trash.mdx).
+2. Copie todo.
+3. En `src/content/services/` → **Add file → Create new file**.
+4. Nombre: `trash.es.mdx`.
+5. Pegue, traduzca el frontmatter:
+
+```yaml
+---
+title: Recolección de basura
+description: Servicio municipal de recolección de basura.
+steps:
+  - Coloque su basura en la bolsa oficial
+  - Sáquela antes de las 6 a.m. el día de recolección
+  - Verifique el horario de su barrio
+documents:
+  - No se requiere documento
+fees: Gratis
+---
+```
+
+6. Traduzca el cuerpo Markdown.
+7. PR.
+
+Si solo traduce parte, está bien — fallback automático al inglés.
+
+> **Importante:** mantenga los **nombres de campos** (`title`, `description`…) en inglés. Solo traduzca los **valores**.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Agregar una noticia
+
+Archivos MDX en [`src/content/news/`](https://github.com/haitiansintech/HaitiCityPortal/tree/main/src/content/news).
+
+Nombre: `YYYY-MM-DD-{slug}.mdx`.
+
+### Ejemplo: preparación huracán, mayo 2026
+
+1. `src/content/news/` → **Add file → Create new file**.
+2. Nombre: `2026-05-20-prep-huracan.es.mdx`.
+3. Pegue:
+
+```mdx
+---
+date: "20 de mayo de 2026"
+dateISO: "2026-05-20"
+title: "Preparación para la temporada de huracanes"
+description: "Lo que cada familia debe hacer antes del 1 de junio."
+---
+
+La temporada de huracanes haitiana empieza el 1 de junio. La oficina del alcalde insta a cada hogar a preparar un kit de emergencia para 72 horas:
+
+- Agua potable (4 litros por persona y día)
+- Alimentos no perecederos
+- Linterna y pilas de repuesto
+- Radio a pilas
+- Botiquín de primeros auxilios
+- Copias de documentos de identidad en bolsa impermeable
+
+Los refugios públicos se activarán según necesidad. Lista en /directory.
+```
+
+4. PR.
+
+Para otros idiomas: repita con `.mdx`, `.fr.mdx`, `.ht.mdx`.
+
+> **Tip:** fechas `YYYY-MM-DD` exactas, ordenamiento automático.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Editar una página estática
+
+Páginas en la raíz de [`src/content/`](https://github.com/haitiansintech/HaitiCityPortal/tree/main/src/content). Mismo formato.
+
+| Página | Archivo |
+|---|---|
+| Acerca | `about.mdx` (+ `.fr.mdx`, `.ht.mdx`, `.es.mdx`) |
+| Privacidad | `privacy.mdx` |
+| Términos | `terms.mdx` |
+| Tech | `tech.mdx` |
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Bases de Markdown
+
+| Sintaxis | Renderiza |
+|---|---|
+| `# Título 1` | Título grande |
+| `## Título 2` | Título de sección |
+| `### Título 3` | Subsección |
+| `**negrita**` | **negrita** |
+| `*cursiva*` | *cursiva* |
+| `- item` | lista con viñetas |
+| `1. item` | lista numerada |
+| `[texto](https://ejemplo.com)` | [texto](https://ejemplo.com) |
+| `![alt](imagen.jpg)` | imagen |
+| `> cita` | cita |
+| ` `código` ` | código en línea |
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Cheat sheet de frontmatter
+
+YAML entre dos `---`.
+
+### Servicio
+
+```yaml
+---
+title: Nombre del servicio
+description: Descripción de una línea
+steps:
+  - Paso 1
+  - Paso 2
+documents:
+  - Documento requerido
+fees: Tarifa (texto)
+---
+```
+
+### Noticia
+
+```yaml
+---
+date: "DD de mes de AAAA"
+dateISO: "AAAA-MM-DD"
+title: "Título"
+description: "Resumen corto."
+---
+```
+
+### Página estática
+
+```yaml
+---
+title: Título
+description: Descripción corta
+---
+```
+
+> **YAML:** strings con dos puntos entre comillas. Listas con `- `. Indentación: 2 espacios, nunca tabulación.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Errores frecuentes
+
+| Error | Resultado | Solución |
+|---|---|---|
+| Renombrar clave JSON | `MISSING_MESSAGE` | Volver a la clave original |
+| Falta `---` de cierre del frontmatter | Página vacía / error | Agregar `---` |
+| Nombre incorrecto de traducción | Ignorada | Respetar `slug.es.mdx`… |
+| `dateISO` mal formateado | Noticia desaparece | `YYYY-MM-DD` estricto |
+| Indentación YAML rota | Error | 2 espacios |
+| Cursiva con `_underscore_` | Comportamiento variable | Preferir `*` |
+| Coma extra en JSON | Archivo no parsea | Eliminar |
+
+Falla CI en PR: lea el mensaje al fondo del PR, indica la línea.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Obtener ayuda
+
+- ¿Bloqueado en una traducción? Abra el PR con "necesita revisión nativa" en la descripción.
+- ¿Bloqueado en Git/GitHub? Issue: <https://github.com/haitiansintech/HaitiCityPortal/issues/new/choose>.
+- Pregunta general: `info@haiticity.org`.
+
+Las contribuciones de contenido son de las más importantes — código bonito sin buenos textos no sirve a nadie.
+
+[↑ Volver arriba](#índice)
+
+---
+
+[← Índice de documentación](README.es.md) · [Manual de Administración](ADMIN_MANUAL.es.md) · [Arquitectura →](ARCHITECTURE.es.md)

--- a/docs/CONTENT_GUIDE.fr.md
+++ b/docs/CONTENT_GUIDE.fr.md
@@ -1,0 +1,310 @@
+<!--
+Langues : English (CONTENT_GUIDE.md) | Français (ce fichier) | Kreyòl (CONTENT_GUIDE.ht.md) | Español (CONTENT_GUIDE.es.md)
+-->
+
+**Langues :** [English](CONTENT_GUIDE.md) · **Français** · [Kreyòl Ayisyen](CONTENT_GUIDE.ht.md) · [Español](CONTENT_GUIDE.es.md)
+
+[← Index de la documentation](README.fr.md) · [README du projet](../README.md) · [Glossaire](GLOSSARY.fr.md)
+
+---
+
+# Guide de contenu
+
+Comment traduire ou modifier du contenu **sans rien installer** — il suffit d'un navigateur et d'un compte GitHub. Pour les traducteurs, équipes communication, et toute personne qui veut améliorer les textes du portail.
+
+## Sommaire
+
+- [Ce que vous pouvez modifier](#ce-que-vous-pouvez-modifier)
+- [Créer un compte GitHub](#créer-un-compte-github)
+- [Modifier un fichier dans GitHub](#modifier-un-fichier-dans-github)
+- [Modifier une étiquette UI (`messages/*.json`)](#modifier-une-étiquette-ui-messagesjson)
+- [Traduire la description d'un service](#traduire-la-description-dun-service)
+- [Ajouter une actualité](#ajouter-une-actualité)
+- [Modifier une page statique (À propos, Confidentialité, Conditions)](#modifier-une-page-statique-à-propos-confidentialité-conditions)
+- [Bases du Markdown](#bases-du-markdown)
+- [Aide-mémoire frontmatter](#aide-mémoire-frontmatter)
+- [Erreurs fréquentes](#erreurs-fréquentes)
+- [Obtenir de l'aide](#obtenir-de-laide)
+
+---
+
+## Ce que vous pouvez modifier
+
+Tout est du texte. Trois emplacements :
+
+| Type | Emplacement | Exemple |
+|---|---|---|
+| Étiquettes UI (textes courts) | `messages/{locale}.json` | « Soumettre », menu de navigation |
+| Services, actualités, pages légales | `src/content/**/*.mdx` | Page service ramassage, article ouragan |
+| Traductions | Mêmes fichiers avec suffixe `.fr.`, `.ht.`, `.es.` | `services/trash.fr.mdx` |
+
+Tout passe par l'interface GitHub. Aucun logiciel à installer.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Créer un compte GitHub
+
+Si vous en avez déjà un, passez.
+
+1. <https://github.com/signup>.
+2. Email, mot de passe, nom d'utilisateur.
+3. Confirmez l'email de vérification.
+4. (Optionnel) Photo et fonction à la mairie.
+
+C'est tout. Plan gratuit suffisant.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Modifier un fichier dans GitHub
+
+Cinq étapes pour toute modification :
+
+1. Connectez-vous sur <https://github.com>.
+2. Allez sur le fichier (liens plus bas).
+3. Cliquez l'**icône crayon** en haut à droite.
+4. Modifiez dans le navigateur.
+5. Descendez. Choisissez **Create a new branch for this commit and start a pull request** (par défaut). **Propose changes**.
+6. Sur l'écran suivant : **Create pull request**.
+
+Un mainteneur examine et fusionne. Quelques minutes après la fusion, votre changement est en ligne.
+
+Si vous n'avez pas l'accès en écriture sur le dépôt principal, GitHub vous proposera de **forker** — acceptez.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Modifier une étiquette UI (`messages/*.json`)
+
+Étiquettes courtes : navbar, boutons, formulaires.
+
+| Langue | Fichier |
+|---|---|
+| Anglais | [`messages/en.json`](https://github.com/haitiansintech/HaitiCityPortal/blob/main/messages/en.json) |
+| Français | [`messages/fr.json`](https://github.com/haitiansintech/HaitiCityPortal/blob/main/messages/fr.json) |
+| Créole haïtien | [`messages/ht.json`](https://github.com/haitiansintech/HaitiCityPortal/blob/main/messages/ht.json) |
+| Espagnol | [`messages/es.json`](https://github.com/haitiansintech/HaitiCityPortal/blob/main/messages/es.json) |
+
+### Exemple : améliorer une traduction française
+
+```json
+{
+  "Nav": {
+    "home": "Accueil",
+    "services": "Services",
+    "report": "Signaler",
+    "pay": "Payer"
+  }
+}
+```
+
+Pour changer « Signaler » en « Signaler un problème » :
+
+1. Crayon.
+2. Modifier la **valeur** (à droite des deux-points, entre guillemets).
+3. PR.
+
+> **Important :** ne renommez **jamais** les **clés** (gauche : `home`, `services`…). Seules les **valeurs** changent.
+
+> **Important :** toute nouvelle clé dans `en.json` doit exister dans les **quatre** fichiers. Sinon `MISSING_MESSAGE` à l'écran.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Traduire la description d'un service
+
+Fichiers MDX dans [`src/content/services/`](https://github.com/haitiansintech/HaitiCityPortal/tree/main/src/content/services).
+
+Base : `{slug}.mdx` (anglais). Traductions : `{slug}.fr.mdx`, `.ht.mdx`, `.es.mdx`.
+
+### Exemple : ajouter la version française pour « Trash Collection »
+
+1. Ouvrez l'anglais : [`src/content/services/trash.mdx`](https://github.com/haitiansintech/HaitiCityPortal/blob/main/src/content/services/trash.mdx).
+2. Copiez tout.
+3. Dans `src/content/services/` → **Add file → Create new file**.
+4. Nom : `trash.fr.mdx`.
+5. Collez et traduisez le frontmatter :
+
+```yaml
+---
+title: Collecte des ordures
+description: Service municipal de collecte des ordures.
+steps:
+  - Mettez vos ordures dans le sac officiel
+  - Sortez-le avant 6 h le jour de collecte
+  - Vérifiez l'horaire de votre quartier
+documents:
+  - Aucun document requis
+fees: Gratuit
+---
+```
+
+6. Traduisez le corps en Markdown.
+7. PR.
+
+Si vous ne traduisez qu'une partie, c'est OK — repli automatique sur l'anglais.
+
+> **Important :** gardez les **noms de champs** (`title`, `description`…) en anglais. Ne traduisez que les **valeurs**.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Ajouter une actualité
+
+Fichiers MDX dans [`src/content/news/`](https://github.com/haitiansintech/HaitiCityPortal/tree/main/src/content/news).
+
+Nommage : `YYYY-MM-DD-{slug}.mdx`.
+
+### Exemple : préparation cyclonique, mai 2026
+
+1. `src/content/news/` → **Add file → Create new file**.
+2. Nom : `2026-05-20-prep-saison-cyclonique.fr.mdx`.
+3. Collez :
+
+```mdx
+---
+date: "20 mai 2026"
+dateISO: "2026-05-20"
+title: "Préparation à la saison cyclonique"
+description: "Ce que chaque famille doit faire avant le 1er juin."
+---
+
+La saison cyclonique haïtienne débute le 1er juin. Le bureau du maire invite chaque foyer à préparer une trousse d'urgence pour 72 heures :
+
+- Eau potable (4 litres par personne et par jour)
+- Aliments non périssables
+- Lampe torche et piles de rechange
+- Radio à piles
+- Trousse de premiers soins
+- Copies des pièces d'identité dans un sac étanche
+
+Les abris publics seront ouverts au besoin. Liste à /directory.
+```
+
+4. PR.
+
+Pour les autres langues : répétez avec `.mdx`, `.ht.mdx`, `.es.mdx`.
+
+> **Astuce :** dates `YYYY-MM-DD` exactement, tri automatique du plus récent au plus ancien.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Modifier une page statique (À propos, Confidentialité, Conditions)
+
+Pages à la racine de [`src/content/`](https://github.com/haitiansintech/HaitiCityPortal/tree/main/src/content). Même format.
+
+| Page | Fichier |
+|---|---|
+| À propos | `about.mdx` (+ `.fr.mdx`, `.ht.mdx`, `.es.mdx`) |
+| Confidentialité | `privacy.mdx` |
+| Conditions | `terms.mdx` |
+| Tech | `tech.mdx` |
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Bases du Markdown
+
+| Syntaxe | Rendu |
+|---|---|
+| `# Titre 1` | Grand titre |
+| `## Titre 2` | Titre de section |
+| `### Titre 3` | Sous-section |
+| `**gras**` | **gras** |
+| `*italique*` | *italique* |
+| `- item` | liste à puces |
+| `1. item` | liste numérotée |
+| `[texte](https://exemple.com)` | [texte](https://exemple.com) |
+| `![alt](image.jpg)` | image |
+| `> citation` | citation |
+| ` `code` ` | code en ligne |
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Aide-mémoire frontmatter
+
+YAML entre deux `---`.
+
+### Service
+
+```yaml
+---
+title: Nom du service
+description: Description en une ligne
+steps:
+  - Étape 1
+  - Étape 2
+documents:
+  - Document requis
+fees: Tarif (texte)
+---
+```
+
+### Actualité
+
+```yaml
+---
+date: "JJ mois AAAA"
+dateISO: "AAAA-MM-JJ"
+title: "Titre"
+description: "Extrait court."
+---
+```
+
+### Page statique
+
+```yaml
+---
+title: Titre
+description: Description courte
+---
+```
+
+> **YAML :** chaînes avec deux-points entre guillemets. Listes avec `- `. Indentation : 2 espaces, jamais de tabulation.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Erreurs fréquentes
+
+| Erreur | Résultat | Correction |
+|---|---|---|
+| Clé JSON renommée | `MISSING_MESSAGE` | Remettre la clé d'origine |
+| `---` de fermeture du frontmatter manquant | Page vide / erreur | Ajouter le `---` |
+| Mauvais nom de traduction | Ignorée | Respecter `slug.fr.mdx`… |
+| `dateISO` mal formaté | Article disparaît | `YYYY-MM-DD` strictement |
+| Indentation YAML cassée | Erreur | 2 espaces |
+| Italique avec `_underscore_` | Comportement variable | Préférer `*` |
+| Virgule en trop dans JSON | Fichier illisible | Supprimer |
+
+Échec CI sur la PR : lisez le message en bas de la PR, il indique la ligne.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Obtenir de l'aide
+
+- Bloqué sur une traduction ? Ouvrez la PR avec « relecture native demandée » dans la description.
+- Bloqué sur Git/GitHub ? Issue : <https://github.com/haitiansintech/HaitiCityPortal/issues/new/choose>.
+- Question générale : `info@haiticity.org`.
+
+Les contributions de contenu sont parmi les plus importantes — un beau code sans bons textes ne sert à personne.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+[← Index de la documentation](README.fr.md) · [Manuel d'administration](ADMIN_MANUAL.fr.md) · [Architecture →](ARCHITECTURE.fr.md)

--- a/docs/CONTENT_GUIDE.ht.md
+++ b/docs/CONTENT_GUIDE.ht.md
@@ -1,0 +1,310 @@
+<!--
+Lang yo: English (CONTENT_GUIDE.md) | Français (CONTENT_GUIDE.fr.md) | Kreyòl (fichye sa a) | Español (CONTENT_GUIDE.es.md)
+-->
+
+**Lang yo:** [English](CONTENT_GUIDE.md) · [Français](CONTENT_GUIDE.fr.md) · **Kreyòl Ayisyen** · [Español](CONTENT_GUIDE.es.md)
+
+[← Endèks dokimantasyon](README.ht.md) · [README pwojè a](../README.md) · [Glosè](GLOSSARY.ht.md)
+
+---
+
+# Gid Kontni
+
+Kijan pou tradwi oswa modifye kontni **san enstale anyen** — sèlman yon navigatè ak yon kont GitHub. Pou tradiktè, ekip kominikasyon, ak nenpòt moun ki vle amelyore tèks pòtal la.
+
+## Tablo Kontni
+
+- [Sa w ka modifye](#sa-w-ka-modifye)
+- [Kreye yon kont GitHub](#kreye-yon-kont-github)
+- [Modifye yon fichye nan GitHub](#modifye-yon-fichye-nan-github)
+- [Modifye yon etikèt UI (`messages/*.json`)](#modifye-yon-etikèt-ui-messagesjson)
+- [Tradwi deskripsyon yon sèvis](#tradwi-deskripsyon-yon-sèvis)
+- [Ajoute yon atik nouvèl](#ajoute-yon-atik-nouvèl)
+- [Modifye yon paj estatik](#modifye-yon-paj-estatik)
+- [Bazil Markdown](#bazil-markdown)
+- [Bilten frontmatter](#bilten-frontmatter)
+- [Erè komen](#erè-komen)
+- [Jwenn èd](#jwenn-èd)
+
+---
+
+## Sa w ka modifye
+
+Tout se tèks. Twa kote:
+
+| Tip | Kote | Egzanp |
+|---|---|---|
+| Etikèt UI (tèks kout) | `messages/{locale}.json` | « Soumèt », meni navigasyon |
+| Sèvis, nouvèl, paj legal | `src/content/**/*.mdx` | Paj sèvis ramasaj, atik siklòn |
+| Tradiksyon | Menm fichye ak sufiks `.fr.`, `.ht.`, `.es.` | `services/trash.ht.mdx` |
+
+Tout pase atravè entèfas GitHub. Pa gen lojisyèl pou enstale.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Kreye yon kont GitHub
+
+Si w deja gen yon, pase.
+
+1. <https://github.com/signup>.
+2. Imèl, modpas, non itilizatè.
+3. Konfime imèl la.
+4. (Opsyonèl) Foto ak wòl ou nan lameri.
+
+Sa fini. Plan gratis ase.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Modifye yon fichye nan GitHub
+
+Senk etap pou chak modifikasyon:
+
+1. Konekte sou <https://github.com>.
+2. Ale sou fichye a (lyen pi ba).
+3. Klike **ikòn kreyon** anwo adwat.
+4. Modifye nan navigatè.
+5. Desann. Chwazi **Create a new branch for this commit and start a pull request** (default). **Propose changes**.
+6. Sou ekran swivan: **Create pull request**.
+
+Yon mainteneur revize epi fizyone. Apre kèk minit fizyon, chanjman ou sou pòtal la.
+
+Si ou pa gen aksè ekriti sou depo prensipal la, GitHub ap pwopoze pou **fork**.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Modifye yon etikèt UI (`messages/*.json`)
+
+Etikèt kout: navbar, bouton, fòm.
+
+| Lang | Fichye |
+|---|---|
+| Anglè | [`messages/en.json`](https://github.com/haitiansintech/HaitiCityPortal/blob/main/messages/en.json) |
+| Franse | [`messages/fr.json`](https://github.com/haitiansintech/HaitiCityPortal/blob/main/messages/fr.json) |
+| Kreyòl | [`messages/ht.json`](https://github.com/haitiansintech/HaitiCityPortal/blob/main/messages/ht.json) |
+| Espanyòl | [`messages/es.json`](https://github.com/haitiansintech/HaitiCityPortal/blob/main/messages/es.json) |
+
+### Egzanp: amelyore yon tradiksyon kreyòl
+
+```json
+{
+  "Nav": {
+    "home": "Akèy",
+    "services": "Sèvis",
+    "report": "Rapòte",
+    "pay": "Peye"
+  }
+}
+```
+
+Pou chanje « Rapòte » an « Siyale yon Pwoblèm »:
+
+1. Kreyon.
+2. Chanje **valè** la (adwat de pwen, nan guillemets).
+3. PR.
+
+> **Enpòtan:** pa janm chanje **kle** yo (agòch: `home`, `services`…). Sèlman **valè** yo chanje.
+
+> **Enpòtan:** chak nouvo kle nan `en.json` dwe egziste nan **kat** fichye yo. Si non, `MISSING_MESSAGE` parèt.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Tradwi deskripsyon yon sèvis
+
+Fichye MDX nan [`src/content/services/`](https://github.com/haitiansintech/HaitiCityPortal/tree/main/src/content/services).
+
+Baz: `{slug}.mdx` (anglè). Tradiksyon: `{slug}.fr.mdx`, `.ht.mdx`, `.es.mdx`.
+
+### Egzanp: ajoute vèsyon kreyòl pou « Trash Collection »
+
+1. Louvri anglè: [`src/content/services/trash.mdx`](https://github.com/haitiansintech/HaitiCityPortal/blob/main/src/content/services/trash.mdx).
+2. Kopye tout.
+3. Nan `src/content/services/` → **Add file → Create new file**.
+4. Non: `trash.ht.mdx`.
+5. Kole, tradwi frontmatter:
+
+```yaml
+---
+title: Ramasaj Fatra
+description: Sèvis minisipal ramasaj fatra.
+steps:
+  - Mete fatra w nan sak ofisyèl la
+  - Soti l avan 6 è jou ramasaj
+  - Verifye orè katye w
+documents:
+  - Pa gen dokiman nesesè
+fees: Gratis
+---
+```
+
+6. Tradwi kò Markdown la.
+7. PR.
+
+Si w sèlman tradwi yon pati, sa OK — sekou otomatik sou anglè.
+
+> **Enpòtan:** kenbe **non chan** (`title`, `description`…) an anglè. Sèlman **valè** yo tradwi.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Ajoute yon atik nouvèl
+
+Fichye MDX nan [`src/content/news/`](https://github.com/haitiansintech/HaitiCityPortal/tree/main/src/content/news).
+
+Non: `YYYY-MM-DD-{slug}.mdx`.
+
+### Egzanp: preparasyon siklòn, me 2026
+
+1. `src/content/news/` → **Add file → Create new file**.
+2. Non: `2026-05-20-prep-siklon.ht.mdx`.
+3. Kole:
+
+```mdx
+---
+date: "20 me 2026"
+dateISO: "2026-05-20"
+title: "Preparasyon pou sezon siklòn"
+description: "Sa chak fanmi dwe fè anvan 1ye jen."
+---
+
+Sezon siklòn ayisyen kòmanse 1ye jen. Biwo majistra a mande chak fwaye prepare yon twous ijans pou 72 èdtan:
+
+- Dlo (4 lit pa moun pa jou)
+- Manje ki pa gate
+- Lanp ak pil rezèv
+- Radyo ak pil
+- Twous premye swen
+- Kopi pyès idantite nan yon sak san dlo
+
+Abri piblik ap louvri si nesesè. Lis nan /directory.
+```
+
+4. PR.
+
+Pou lòt lang: repete ak `.mdx`, `.fr.mdx`, `.es.mdx`.
+
+> **Konsèy:** dat `YYYY-MM-DD` egzakteman, tri otomatik.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Modifye yon paj estatik
+
+Paj nan rasin [`src/content/`](https://github.com/haitiansintech/HaitiCityPortal/tree/main/src/content). Menm fòma.
+
+| Paj | Fichye |
+|---|---|
+| Apropo | `about.mdx` (+ `.fr.mdx`, `.ht.mdx`, `.es.mdx`) |
+| Vi prive | `privacy.mdx` |
+| Kondisyon | `terms.mdx` |
+| Tech | `tech.mdx` |
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Bazil Markdown
+
+| Sentaks | Rann |
+|---|---|
+| `# Tit 1` | Gwo tit |
+| `## Tit 2` | Tit seksyon |
+| `### Tit 3` | Sou-seksyon |
+| `**fò**` | **fò** |
+| `*italik*` | *italik* |
+| `- item` | lis pwen |
+| `1. item` | lis nimewote |
+| `[tèks](https://egzanp.com)` | [tèks](https://egzanp.com) |
+| `![alt](image.jpg)` | imaj |
+| `> sitasyon` | sitasyon |
+| ` `kòd` ` | kòd anliy |
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Bilten frontmatter
+
+YAML ant de `---`.
+
+### Sèvis
+
+```yaml
+---
+title: Non sèvis la
+description: Deskripsyon yon liy
+steps:
+  - Etap 1
+  - Etap 2
+documents:
+  - Dokiman nesesè
+fees: Pri (tèks)
+---
+```
+
+### Atik
+
+```yaml
+---
+date: "JJ mwa AAAA"
+dateISO: "AAAA-MM-JJ"
+title: "Tit"
+description: "Ekstrè kout."
+---
+```
+
+### Paj estatik
+
+```yaml
+---
+title: Tit
+description: Ti deskripsyon
+---
+```
+
+> **YAML:** chèn ak de pwen nan guillemets. Lis ak `- `. Endantasyon: 2 espas, pa janm tab.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Erè komen
+
+| Erè | Rezilta | Solisyon |
+|---|---|---|
+| Kle JSON chanje | `MISSING_MESSAGE` | Remete kle orijinal |
+| `---` fèmti frontmatter manke | Paj vid / erè | Ajoute `---` |
+| Move non tradiksyon | Inyore | Respekte `slug.ht.mdx`… |
+| `dateISO` move fòma | Atik disparèt | `YYYY-MM-DD` strikt |
+| Endantasyon YAML kase | Erè | 2 espas |
+| Italik ak `_underscore_` | Komportman varye | Prefere `*` |
+| Vigil anplis nan JSON | Fichye pa li | Retire |
+
+Echèk CI sou PR: li mesaj an ba PR a, li montre liy lan.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Jwenn èd
+
+- Bloke sou yon tradiksyon? Louvri PR ak « bezwen revizyon natif » nan deskripsyon.
+- Bloke sou Git/GitHub? Issue: <https://github.com/haitiansintech/HaitiCityPortal/issues/new/choose>.
+- Kesyon jeneral: `info@haiticity.org`.
+
+Kontribisyon kontni se nan pi enpòtan yo — bèl kòd san bon tèks pa sèvi pèsòn.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+[← Endèks dokimantasyon](README.ht.md) · [Manyèl Administrasyon](ADMIN_MANUAL.ht.md) · [Achitekti →](ARCHITECTURE.ht.md)

--- a/docs/CONTENT_GUIDE.md
+++ b/docs/CONTENT_GUIDE.md
@@ -1,0 +1,320 @@
+<!--
+Languages: English (this file) | Français (CONTENT_GUIDE.fr.md) | Kreyòl (CONTENT_GUIDE.ht.md) | Español (CONTENT_GUIDE.es.md)
+-->
+
+**Languages:** **English** · [Français](CONTENT_GUIDE.fr.md) · [Kreyòl Ayisyen](CONTENT_GUIDE.ht.md) · [Español](CONTENT_GUIDE.es.md)
+
+[← Docs index](README.md) · [Project README](../README.md) · [Glossary](GLOSSARY.md)
+
+---
+
+# Content Guide
+
+How to translate or edit content **without installing anything** — only a web browser and a GitHub account. Designed for translators, communications staff, and anyone who wants to improve the portal's text.
+
+## Table of Contents
+
+- [What you can edit](#what-you-can-edit)
+- [Setting up a GitHub account](#setting-up-a-github-account)
+- [Editing a file in the GitHub web UI](#editing-a-file-in-the-github-web-ui)
+- [Editing a UI label (`messages/*.json`)](#editing-a-ui-label-messagesjson)
+- [Translating a service description](#translating-a-service-description)
+- [Adding a news article](#adding-a-news-article)
+- [Editing a static page (About, Privacy, Terms)](#editing-a-static-page-about-privacy-terms)
+- [Markdown basics](#markdown-basics)
+- [Frontmatter cheat sheet](#frontmatter-cheat-sheet)
+- [Common mistakes](#common-mistakes)
+- [Getting help](#getting-help)
+
+---
+
+## What you can edit
+
+Everything is text. Three places hold content:
+
+| Type | Location | Example |
+|---|---|---|
+| UI labels (short text) | `messages/{locale}.json` | "Submit", "Pay now", nav menu items |
+| Service descriptions, news, legal pages | `src/content/**/*.mdx` | Trash service page, hurricane news article |
+| Translations of either | Same files with `.fr.`, `.ht.`, `.es.` suffix | `services/trash.fr.mdx` |
+
+Editing happens through GitHub's web UI. No software to install. No Git knowledge required.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Setting up a GitHub account
+
+If you already have one, skip this.
+
+1. Go to <https://github.com/signup>.
+2. Enter your email, create a password and username.
+3. Confirm the verification email.
+4. (Optional) Add a profile photo and your role at the commune.
+
+That's it. You don't need any GitHub plan beyond the free tier.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Editing a file in the GitHub web UI
+
+Same five steps for every edit:
+
+1. Sign in at <https://github.com>.
+2. Navigate to the file you want to edit (links below).
+3. Click the **pencil icon** in the upper right.
+4. Make your edits in the browser.
+5. Scroll down. Choose **Create a new branch for this commit and start a pull request** (the default is fine for most edits). Click **Propose changes**.
+6. On the next screen click **Create pull request**.
+
+A maintainer will review and merge it. Within a few minutes of merging, your change is live on the portal.
+
+If you don't have write access to the main repository, GitHub will offer to **fork** it for you — accept this. Your edit goes into your own copy of the project, and the Pull Request asks the project to merge your improvement.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Editing a UI label (`messages/*.json`)
+
+UI labels are short pieces of text in the navbar, buttons, form labels, etc.
+
+Each language has its own JSON file:
+
+| Language | File |
+|---|---|
+| English | [`messages/en.json`](https://github.com/haitiansintech/HaitiCityPortal/blob/main/messages/en.json) |
+| French | [`messages/fr.json`](https://github.com/haitiansintech/HaitiCityPortal/blob/main/messages/fr.json) |
+| Haitian Creole | [`messages/ht.json`](https://github.com/haitiansintech/HaitiCityPortal/blob/main/messages/ht.json) |
+| Spanish | [`messages/es.json`](https://github.com/haitiansintech/HaitiCityPortal/blob/main/messages/es.json) |
+
+### Example: improving a Creole translation
+
+Open `messages/ht.json`. You see something like:
+
+```json
+{
+  "Nav": {
+    "home": "Akèy",
+    "services": "Sèvis",
+    "report": "Rapòte",
+    "pay": "Peye"
+  }
+}
+```
+
+To improve "Rapòte" to "Siyale yon Pwoblèm":
+
+1. Click the pencil icon.
+2. Change the value (the right side of the colon, in quotes).
+3. Submit a Pull Request as described above.
+
+> **Important:** never change the **keys** (left side: `home`, `services`, `report`, `pay`). The keys are referenced in code. Only change the **values** (the translations).
+
+> **Important:** if you add a new key in `en.json`, you must add it in **all four** language files. Otherwise the page will display a `MISSING_MESSAGE` error.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Translating a service description
+
+Service descriptions are MDX files in [`src/content/services/`](https://github.com/haitiansintech/HaitiCityPortal/tree/main/src/content/services).
+
+The base file is `{slug}.mdx` (English). Translations are `{slug}.fr.mdx`, `{slug}.ht.mdx`, `{slug}.es.mdx`.
+
+### Example: adding a Creole translation for "Trash Collection"
+
+1. Open the English version: [`src/content/services/trash.mdx`](https://github.com/haitiansintech/HaitiCityPortal/blob/main/src/content/services/trash.mdx).
+2. Copy its full contents.
+3. In a new tab, navigate to `src/content/services/`.
+4. Click **Add file → Create new file**.
+5. Name it `trash.ht.mdx`.
+6. Paste the English contents.
+7. Translate the values in the frontmatter (the YAML between `---` lines):
+   ```yaml
+   ---
+   title: Ramasaj Fatra
+   description: Sèvis ramasaj fatra nan komin lan.
+   steps:
+     - Mete fatra w nan sak ki gen koulè
+     - Pote l deyò pòt jou ramasaj la
+     - Verifye orè a
+   documents:
+     - Okenn dokiman pa nesesè
+   fees: Gratis
+   ---
+   ```
+8. Translate the markdown body below the frontmatter.
+9. Submit the Pull Request.
+
+If you only translate part of the file, that's fine — the system falls back to English for any missing piece.
+
+> **Important:** keep the frontmatter **field names** (`title`, `description`, `steps`, `documents`, `fees`) in English. Only translate their **values**.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Adding a news article
+
+News articles are MDX files in [`src/content/news/`](https://github.com/haitiansintech/HaitiCityPortal/tree/main/src/content/news).
+
+Filename pattern: `YYYY-MM-DD-{short-slug}.mdx`.
+
+### Example: hurricane preparedness, May 2026
+
+1. Navigate to `src/content/news/`.
+2. **Add file → Create new file**.
+3. Name it `2026-05-20-hurricane-prep.mdx`.
+4. Paste this template:
+
+```mdx
+---
+date: "May 20, 2026"
+dateISO: "2026-05-20"
+title: "Hurricane season preparedness"
+description: "What every family should do before June 1."
+---
+
+The Haitian hurricane season begins June 1. The mayor's office urges every household to prepare a 72-hour emergency kit:
+
+- Drinking water (4 litres per person per day)
+- Non-perishable food
+- Flashlight and spare batteries
+- Battery-powered radio
+- First-aid kit
+- Copies of identity documents in a waterproof bag
+
+Public shelters will be activated as needed. The list is published at /directory.
+```
+
+5. Submit the Pull Request.
+6. Within minutes of merge, the article appears on the homepage and at `/news`.
+
+To translate, repeat with `2026-05-20-hurricane-prep.fr.mdx`, `.ht.mdx`, `.es.mdx`.
+
+> **Tip:** date filenames sort alphabetically, so newest-first ordering is automatic. Use `YYYY-MM-DD` exactly.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Editing a static page (About, Privacy, Terms)
+
+Static pages live at the root of [`src/content/`](https://github.com/haitiansintech/HaitiCityPortal/tree/main/src/content). Same format and same workflow as services and news.
+
+| Page | File |
+|---|---|
+| About | `about.mdx` (and `.fr.mdx`, `.ht.mdx`, `.es.mdx`) |
+| Privacy | `privacy.mdx` |
+| Terms | `terms.mdx` |
+| Tech | `tech.mdx` |
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Markdown basics
+
+Markdown is a simple text format. Here are the only things you need:
+
+| Syntax | Renders as |
+|---|---|
+| `# Heading 1` | Big title |
+| `## Heading 2` | Section title |
+| `### Heading 3` | Sub-section |
+| `**bold**` | **bold** |
+| `*italic*` | *italic* |
+| `- item` | bullet list |
+| `1. item` | numbered list |
+| `[link text](https://example.com)` | [link text](https://example.com) |
+| `![alt text](image.jpg)` | image |
+| `> quote` | blockquote |
+| ` `code` ` | inline code |
+
+That's all you need. No HTML, no fancy tricks.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Frontmatter cheat sheet
+
+Frontmatter is the structured block at the top of every MDX file, between two `---` lines. It's YAML.
+
+### Service page
+
+```yaml
+---
+title: Service name (display)
+description: One-line description for cards
+steps:
+  - Step one
+  - Step two
+documents:
+  - Document required
+fees: Fee description (a string, e.g. "100 HTG" or "Free")
+---
+```
+
+### News article
+
+```yaml
+---
+date: "Month DD, YYYY"
+dateISO: "YYYY-MM-DD"
+title: "Article title"
+description: "Short excerpt."
+---
+```
+
+### Static page
+
+```yaml
+---
+title: Page title
+description: Short page description
+---
+```
+
+> **YAML quirks:** strings with colons or special characters need to be in quotes. Lists use `- ` (dash space) at the start of each line. Indentation matters — use two spaces.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Common mistakes
+
+| Mistake | Result | Fix |
+|---|---|---|
+| Renamed a JSON key (left side) | Page shows `MISSING_MESSAGE` | Rename it back; keys are code references |
+| Forgot the closing `---` after frontmatter | Page is blank or errors | Add the second `---` |
+| Wrong filename for a translation | The translation is silently ignored | Match the pattern exactly: `slug.fr.mdx`, etc. |
+| Changed dateISO format | News article disappears or sorts wrong | Use `YYYY-MM-DD` only |
+| Broke YAML indentation | Page errors | Two-space indent, never tab |
+| Used Markdown `_underscore_` for italics | Sometimes works, sometimes weird | Prefer `*asterisks*` |
+| Trailing comma in JSON | File won't parse | Remove the trailing comma |
+
+If a Pull Request fails CI checks (red X), don't panic — read the message at the bottom of the PR. It usually points to the line. Fix and push again.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Getting help
+
+- **Stuck on a translation?** Open the PR anyway — note in the description "needs review by native speaker".
+- **Stuck on Git/GitHub?** Open an issue: <https://github.com/haitiansintech/HaitiCityPortal/issues/new/choose>.
+- **General questions:** `info@haiticity.org`.
+
+We deeply value content contributions. They are often the highest-impact changes — code without good text helps nobody.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+[← Docs index](README.md) · [Admin Manual](ADMIN_MANUAL.md) · [Architecture →](ARCHITECTURE.md)

--- a/docs/DEPLOYMENT.es.md
+++ b/docs/DEPLOYMENT.es.md
@@ -1,0 +1,382 @@
+<!--
+Idiomas: English (DEPLOYMENT.md) | Français (DEPLOYMENT.fr.md) | Kreyòl (DEPLOYMENT.ht.md) | Español (este archivo)
+-->
+
+**Idiomas:** [English](DEPLOYMENT.md) · [Français](DEPLOYMENT.fr.md) · [Kreyòl Ayisyen](DEPLOYMENT.ht.md) · **Español**
+
+[← Índice de documentación](README.es.md) · [README del proyecto](../README.md) · [Glosario](GLOSSARY.es.md)
+
+---
+
+# Despliegue
+
+Guía paso a paso para desplegar Haiti City Portal en producción. Documento dirigido al desarrollador o líder de TI que operará el servicio en vivo.
+
+## Índice
+
+- [Prerrequisitos](#prerrequisitos)
+- [Vista general de la arquitectura](#vista-general-de-la-arquitectura)
+- [Paso 1 — Dominio](#paso-1--dominio)
+- [Paso 2 — DNS comodín](#paso-2--dns-comodín)
+- [Paso 3 — Base de datos (Neon)](#paso-3--base-de-datos-neon)
+- [Paso 4 — Hosting (Vercel)](#paso-4--hosting-vercel)
+- [Paso 5 — Variables de entorno](#paso-5--variables-de-entorno)
+- [Paso 6 — Esquema inicial y seed](#paso-6--esquema-inicial-y-seed)
+- [Paso 7 — Conectar el dominio a Vercel](#paso-7--conectar-el-dominio-a-vercel)
+- [Paso 8 — Verificar el despliegue](#paso-8--verificar-el-despliegue)
+- [Paso 9 — Agregar su primer tenant](#paso-9--agregar-su-primer-tenant)
+- [Actualizar la aplicación](#actualizar-la-aplicación)
+- [Respaldos y recuperación](#respaldos-y-recuperación)
+- [Monitoreo y logs](#monitoreo-y-logs)
+- [Resumen de costos](#resumen-de-costos)
+- [Plataformas alternativas](#plataformas-alternativas)
+- [Solución de problemas](#solución-de-problemas)
+
+---
+
+## Prerrequisitos
+
+En su computadora:
+
+- [Node.js 20+](https://nodejs.org/)
+- [Git](https://git-scm.com/)
+- [GitHub CLI](https://cli.github.com/) (`gh`) — opcional
+- Editor (VS Code, Cursor)
+
+Cuentas necesarias:
+
+- [GitHub](https://github.com) — para forkear el repo
+- Un registrador de dominio (Namecheap, Cloudflare, Porkbun…)
+- [Vercel](https://vercel.com) — hosting
+- [Neon](https://neon.tech) — base PostgreSQL
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Vista general de la arquitectura
+
+En producción:
+
+```
+        Internet
+           │
+           ▼
+   ┌───────────────┐       (cada comuna tiene su subdominio)
+   │ Cloudflare/   │       ej.   jacmel.portal.ht
+   │ Registrador   │             cap.portal.ht
+   │ DNS comodín   │             demo.portal.ht
+   │ *.portal.ht   │
+   └───────┬───────┘
+           │
+           ▼
+   ┌───────────────┐       App Next.js:
+   │    Vercel     │       - middleware lee Host → tenant
+   │  (Next.js 15) │       - server components consultan BD
+   └───────┬───────┘       - HTTPS automático
+           │
+           ▼
+   ┌───────────────┐       Postgres 16:
+   │     Neon      │       - una base compartida
+   │  (PostgreSQL) │       - filas filtradas por tenant_id
+   └───────────────┘
+```
+
+Vea [Arquitectura](ARCHITECTURE.es.md) para el diagrama completo.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Paso 1 — Dominio
+
+Un solo dominio que todas las comunas compartirán como subdominios.
+
+Recomendado: un `.ht` por identidad haitiana, pero cualquier TLD funciona.
+
+| Registrador | Notas |
+|---|---|
+| Cloudflare | Renovaciones más baratas, DNS excelente, SSL gratis |
+| Namecheap | Interfaz simple, buen soporte |
+| Porkbun | Económico, moderno |
+
+Tras la compra, **apunte los nameservers de su dominio a Cloudflare** si compró en otro lugar.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Paso 2 — DNS comodín
+
+Multi-tenant requiere un registro DNS comodín.
+
+En su proveedor DNS (Cloudflare aquí), agregue **dos CNAME**:
+
+| Tipo | Nombre | Destino | Proxy |
+|---|---|---|---|
+| CNAME | `@` (apex) | `cname.vercel-dns.com` | DNS only (nube gris) |
+| CNAME | `*` | `cname.vercel-dns.com` | DNS only (nube gris) |
+
+El `*` permite que `jacmel.portal.ht`, `cap.portal.ht` y cualquier comuna futura resuelvan automáticamente.
+
+> **Importante:** en Cloudflare, ponga los registros en "DNS only" (nube gris) al inicio. Vercel debe emitir SSL para cada subdominio.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Paso 3 — Base de datos (Neon)
+
+1. Inicie sesión en [neon.tech](https://neon.tech).
+2. Cree un **Proyecto** `haiti-city-portal-prod`.
+3. Elija la región más cercana: **AWS US East 2 (Ohio)** o **US East 1 (N. Virginia)**.
+4. Copie la **cadena de conexión**:
+   ```
+   postgresql://USER:PASSWORD@ep-xxx.us-east-2.aws.neon.tech/neondb?sslmode=require
+   ```
+5. Será la variable `DATABASE_URL` en el paso 5.
+
+> **Consejo:** el plan gratis de Neon es generoso. Empiece gratis y pase a "Launch" (~$19/mes) cuando crezca el uso.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Paso 4 — Hosting (Vercel)
+
+### 4.1 Forkear el repositorio
+
+1. Vaya a [github.com/haitiansintech/HaitiCityPortal](https://github.com/haitiansintech/HaitiCityPortal).
+2. Clic en **Fork** arriba a la derecha.
+3. (Opcional) Renombre su fork (`mairie-jacmel-portal`).
+
+### 4.2 Importar a Vercel
+
+1. Inicie sesión en [vercel.com](https://vercel.com) con GitHub.
+2. **Add New… → Project**.
+3. Seleccione su fork.
+4. **Framework preset**: Next.js (auto-detectado).
+5. **Root directory**: por defecto.
+6. **Build & output settings**: por defecto.
+7. **No haga clic en Deploy** todavía — primero agregue las variables (paso 5).
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Paso 5 — Variables de entorno
+
+En la configuración de Vercel:
+
+| Variable | ¿Requerida? | Ejemplo |
+|---|---|---|
+| `DATABASE_URL` | **Sí** | `postgresql://USER:PASS@ep-xxx.us-east-2.aws.neon.tech/neondb?sslmode=require` |
+| `AUTH_SECRET` | **Sí** | Cadena aleatoria 32+ caracteres. `openssl rand -base64 32` |
+| `NEXTAUTH_URL` | **Sí** | `https://portal.ht` |
+| `AUTH_TRUST_HOST` | Recomendada | `true` |
+| `NEXT_PUBLIC_BASE_URL` | Opcional | `https://portal.ht` |
+| `ENABLE_LOCAL_MODE` | Debe estar **sin definir o `false`** en producción | (no definir) |
+
+Plantilla anotada completa: [`.env.production.example`](../.env.production.example).
+
+> **Atención:** nunca commitee secretos a GitHub. Vercel cifra las variables.
+
+Clic en **Deploy**.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Paso 6 — Esquema inicial y seed
+
+El primer despliegue arranca la app, pero la base está vacía.
+
+### 6.1 Empujar el esquema
+
+Desde su computadora:
+
+```bash
+git clone https://github.com/SU-ORG/HaitiCityPortal.git
+cd HaitiCityPortal
+npm install
+echo 'DATABASE_URL="<su cadena Neon>"' > .env.local
+npm run db:push
+```
+
+### 6.2 Seed del primer tenant
+
+```bash
+$env:CONFIRM_PRODUCTION_SEED="yes"
+$env:SEED_ADMIN_EMAIL="admin@su-dominio.ht"
+$env:SEED_ADMIN_PASSWORD="<contraseña fuerte y única>"
+$env:SEED_TENANT_NAME="Ville de Jacmel"
+$env:SEED_TENANT_SUBDOMAIN="jacmel"
+
+npm run db:seed:prod
+```
+
+(En macOS/Linux: `export VAR=valor`.)
+
+Crea:
+- Una fila `tenants` con su subdominio.
+- Una fila `users` superadmin con el correo y contraseña hasheada.
+
+Inicie sesión en `https://jacmel.portal.ht/login` cuando el DNS resuelva (paso 7).
+
+Para agregar más comunas: [Alta de Municipio](TENANT_ONBOARDING.es.md).
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Paso 7 — Conectar el dominio a Vercel
+
+En Vercel:
+
+1. **Settings → Domains**.
+2. Agregue `portal.ht`.
+3. Agregue `*.portal.ht` (el comodín).
+4. Vercel verifica el DNS (paso 2) y emite SSL automáticamente.
+
+Después:
+- `https://portal.ht` → llega a la app.
+- `https://jacmel.portal.ht` → llega a su tenant Jacmel.
+
+> **Dominio apex:** si su registrador no soporta CNAME en el apex, use los registros A recomendados por Vercel. Cloudflare y Porkbun manejan CNAME-flattening.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Paso 8 — Verificar el despliegue
+
+Lista de chequeo:
+
+- [ ] `https://portal.ht` responde.
+- [ ] `https://jacmel.portal.ht` responde.
+- [ ] `https://jacmel.portal.ht/api/health` retorna OK.
+- [ ] Cambio de idioma: `/en/`, `/fr/`, `/ht/`, `/es/`.
+- [ ] Login en `/login` con su admin.
+- [ ] Acceso a una página admin (`/admin`).
+- [ ] Candado HTTPS válido.
+
+Si algo falla: [Solución de problemas](#solución-de-problemas).
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Paso 9 — Agregar su primer tenant
+
+Si seedeó un tenant en el paso 6, está listo. Pase a cargar datos vía admin — vea [Manual de Administración](ADMIN_MANUAL.es.md).
+
+Para más comunas: [Alta de Municipio](TENANT_ONBOARDING.es.md).
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Actualizar la aplicación
+
+Cuando llegue código nuevo del upstream:
+
+1. Sincronice su fork: GitHub → su fork → botón **Sync fork**.
+2. Vercel redespliega automáticamente en cada push a `main`.
+3. Si hay cambio de esquema, ejecute `npm run db:push` contra producción (o automatice en CI).
+
+Recomendado: un entorno `staging` en Vercel con base Neon separada para probar primero.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Respaldos y recuperación
+
+| Riesgo | Mitigación |
+|---|---|
+| Pérdida de base | Snapshots automáticos Neon. Planes pagos: 30 días. |
+| Bug aplicativo | Vercel guarda todos los despliegues. **Promote to Production** = rollback instantáneo. |
+| Secuestro de DNS | 2FA en registrador y proveedor DNS. |
+| Contraseña admin perdida | Resetear vía Drizzle Studio o re-seed. |
+| `AUTH_SECRET` perdido | Rotar = cierra todas las sesiones. Guardar en gestor de contraseñas. |
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Monitoreo y logs
+
+- **Logs de Vercel**: Settings → Logs.
+- **Panel Neon**: rendimiento y almacenamiento.
+- Opcional: **Sentry** para errores aplicativos.
+- Opcional: **Better Stack / Pingdom** sobre `/api/health`.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Resumen de costos
+
+| Componente | Gratis | Estándar pago |
+|---|---|---|
+| Vercel | $0 | $20/usuario/mes (Pro) |
+| Neon | $0 | $19/mes (Launch) |
+| Cloudflare DNS | $0 | $0 |
+| Dominio `.ht` | n/a | ~$30/año |
+| Total | **~$0/mes + $30/año** | **~$40/mes + $30/año** |
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Plataformas alternativas
+
+Es Next.js 15 estándar; corre donde corra Node.js.
+
+| Alternativa | Notas |
+|---|---|
+| VPS auto-hospedado (Hetzner, Linode, OVH) | Docker; ~$5–20/mes; usted maneja SSL y respaldos |
+| Cloudflare Pages + Workers | Posible con adaptadores; algunas funciones limitadas |
+| Fly.io | Bueno para Postgres + Next.js auto-hospedados |
+| Railway | Experiencia similar a Vercel |
+| Render | Experiencia similar a Vercel |
+| AWS, GCP, Azure | Posible pero pesado; no recomendado para primer despliegue |
+
+Auto-hospedado: usted maneja SSL, certificado wildcard, gestión de procesos, respaldos Postgres.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Solución de problemas
+
+### Subdominio retorna "404 Not Found"
+- Verifique que el CNAME comodín exista.
+- Verifique que `*.portal.ht` esté en Vercel **Settings → Domains**.
+- La emisión SSL puede tardar 1–10 minutos la primera vez.
+
+### "DB unavailable, using fallback tenant"
+- `DATABASE_URL` faltante o incorrecta.
+- Base Neon pausada (free tier se auto-pausa tras 5 min de inactividad).
+- Cadena sin `?sslmode=require`.
+
+### "MISSING_MESSAGE" o "FORMATTING_ERROR"
+- Falta una clave en `messages/{locale}.json`. Verifique paridad de claves.
+
+### Bucle de redirección al login
+- `NEXTAUTH_URL` no coincide con la URL real.
+- `AUTH_SECRET` sin definir o < 32 caracteres.
+- `AUTH_TRUST_HOST` no es `true`.
+
+### `npm run db:push` falla
+- Pruebe primero la conexión `psql`.
+- Verifique la región del proyecto Neon.
+
+### Build de Vercel falla en primer despliegue
+- Revise variables faltantes en el log.
+
+[↑ Volver arriba](#índice)
+
+---
+
+[← Índice de documentación](README.es.md) · [Para Municipalidades](FOR_MUNICIPALITIES.es.md) · [Alta de Municipio →](TENANT_ONBOARDING.es.md)

--- a/docs/DEPLOYMENT.fr.md
+++ b/docs/DEPLOYMENT.fr.md
@@ -1,0 +1,382 @@
+<!--
+Langues : English (DEPLOYMENT.md) | Français (ce fichier) | Kreyòl (DEPLOYMENT.ht.md) | Español (DEPLOYMENT.es.md)
+-->
+
+**Langues :** [English](DEPLOYMENT.md) · **Français** · [Kreyòl Ayisyen](DEPLOYMENT.ht.md) · [Español](DEPLOYMENT.es.md)
+
+[← Index de la documentation](README.fr.md) · [README du projet](../README.md) · [Glossaire](GLOSSARY.fr.md)
+
+---
+
+# Déploiement
+
+Guide étape par étape pour déployer Haiti City Portal en production. Document destiné au développeur ou au responsable IT qui exploitera le service en ligne.
+
+## Sommaire
+
+- [Prérequis](#prérequis)
+- [Vue d'ensemble de l'architecture](#vue-densemble-de-larchitecture)
+- [Étape 1 — Domaine](#étape-1--domaine)
+- [Étape 2 — DNS wildcard](#étape-2--dns-wildcard)
+- [Étape 3 — Base de données (Neon)](#étape-3--base-de-données-neon)
+- [Étape 4 — Hébergement (Vercel)](#étape-4--hébergement-vercel)
+- [Étape 5 — Variables d'environnement](#étape-5--variables-denvironnement)
+- [Étape 6 — Schéma initial et seed](#étape-6--schéma-initial-et-seed)
+- [Étape 7 — Connecter le domaine à Vercel](#étape-7--connecter-le-domaine-à-vercel)
+- [Étape 8 — Vérifier le déploiement](#étape-8--vérifier-le-déploiement)
+- [Étape 9 — Ajouter votre premier tenant](#étape-9--ajouter-votre-premier-tenant)
+- [Mettre à jour l'application](#mettre-à-jour-lapplication)
+- [Sauvegardes et reprise](#sauvegardes-et-reprise)
+- [Supervision et logs](#supervision-et-logs)
+- [Récapitulatif des coûts](#récapitulatif-des-coûts)
+- [Plateformes alternatives](#plateformes-alternatives)
+- [Dépannage](#dépannage)
+
+---
+
+## Prérequis
+
+Sur votre poste :
+
+- [Node.js 20+](https://nodejs.org/)
+- [Git](https://git-scm.com/)
+- [GitHub CLI](https://cli.github.com/) (`gh`) — optionnel
+- Un éditeur (VS Code, Cursor, etc.)
+
+Comptes nécessaires :
+
+- [GitHub](https://github.com) — pour forker le dépôt
+- Un bureau d'enregistrement de domaine (Namecheap, Cloudflare, Porkbun…)
+- [Vercel](https://vercel.com) — hébergement
+- [Neon](https://neon.tech) — base PostgreSQL
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Vue d'ensemble de l'architecture
+
+En production :
+
+```
+        Internet
+           │
+           ▼
+   ┌───────────────┐       (chaque commune a son sous-domaine)
+   │  Cloudflare/  │       ex.   jacmel.portal.ht
+   │ Bureau DNS    │             cap.portal.ht
+   │ wildcard DNS  │             demo.portal.ht
+   │ *.portal.ht   │
+   └───────┬───────┘
+           │
+           ▼
+   ┌───────────────┐       App Next.js :
+   │    Vercel     │       - middleware lit Host → tenant
+   │  (Next.js 15) │       - server components requêtent la BD
+   └───────┬───────┘       - HTTPS automatique
+           │
+           ▼
+   ┌───────────────┐       Postgres 16 :
+   │     Neon      │       - une base partagée
+   │  (PostgreSQL) │       - lignes filtrées par tenant_id
+   └───────────────┘
+```
+
+Voir [Architecture](ARCHITECTURE.fr.md) pour le diagramme complet.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Étape 1 — Domaine
+
+Un seul domaine que toutes les communes partageront comme sous-domaines.
+
+Recommandé : un `.ht` pour la lisibilité haïtienne, mais tout TLD fonctionne.
+
+| Bureau | Notes |
+|---|---|
+| Cloudflare | Renouvellements moins chers, excellent DNS, SSL gratuit |
+| Namecheap | Interface simple, bon support |
+| Porkbun | Pas cher, interface moderne |
+
+Après l'achat, **pointez les nameservers de votre domaine vers Cloudflare** si vous avez acheté ailleurs — DNS le plus simple pour les wildcards.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Étape 2 — DNS wildcard
+
+Le multi-tenant exige un enregistrement DNS wildcard.
+
+Chez votre fournisseur DNS (Cloudflare ici), ajoutez **deux CNAME** :
+
+| Type | Nom | Cible | Proxy |
+|---|---|---|---|
+| CNAME | `@` (apex) | `cname.vercel-dns.com` | DNS only (nuage gris) |
+| CNAME | `*` | `cname.vercel-dns.com` | DNS only (nuage gris) |
+
+Le `*` permet à `jacmel.portal.ht`, `cap.portal.ht` et toute future commune de résoudre automatiquement.
+
+> **Important :** sur Cloudflare, mettez les enregistrements en « DNS only » (nuage gris) au début. Vercel doit émettre un certificat SSL pour chaque sous-domaine et le proxy de Cloudflare peut interférer. Vous pourrez activer le proxy plus tard.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Étape 3 — Base de données (Neon)
+
+1. Connectez-vous sur [neon.tech](https://neon.tech).
+2. Créez un **Projet** `haiti-city-portal-prod`.
+3. Choisissez la région la plus proche : **AWS US East 2 (Ohio)** ou **US East 1 (Virginie)**.
+4. Copiez la **chaîne de connexion** :
+   ```
+   postgresql://USER:PASSWORD@ep-xxx.us-east-2.aws.neon.tech/neondb?sslmode=require
+   ```
+5. Ce sera la variable `DATABASE_URL` à l'étape 5.
+
+> **Astuce :** la formule gratuite de Neon est généreuse. Vous pouvez démarrer gratuitement et passer au plan « Launch » (~19 $/mois) quand l'usage croît.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Étape 4 — Hébergement (Vercel)
+
+### 4.1 Forker le dépôt
+
+1. Allez sur [github.com/haitiansintech/HaitiCityPortal](https://github.com/haitiansintech/HaitiCityPortal).
+2. Cliquez **Fork** en haut à droite.
+3. (Optionnel) Renommez votre fork (`mairie-jacmel-portal`).
+
+### 4.2 Importer dans Vercel
+
+1. Connectez-vous sur [vercel.com](https://vercel.com) avec GitHub.
+2. **Add New… → Project**.
+3. Sélectionnez votre fork.
+4. **Framework preset** : Next.js (auto-détecté).
+5. **Root directory** : par défaut.
+6. **Build & output settings** : par défaut.
+7. **Ne cliquez pas Deploy** maintenant — ajoutez d'abord les variables (étape 5).
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Étape 5 — Variables d'environnement
+
+Dans les paramètres Vercel (ou pendant l'import) :
+
+| Variable | Requise ? | Exemple |
+|---|---|---|
+| `DATABASE_URL` | **Oui** | `postgresql://USER:PASS@ep-xxx.us-east-2.aws.neon.tech/neondb?sslmode=require` |
+| `AUTH_SECRET` | **Oui** | Chaîne aléatoire 32+ caractères. `openssl rand -base64 32` |
+| `NEXTAUTH_URL` | **Oui** | `https://portal.ht` |
+| `AUTH_TRUST_HOST` | Recommandée | `true` |
+| `NEXT_PUBLIC_BASE_URL` | Optionnelle | `https://portal.ht` |
+| `ENABLE_LOCAL_MODE` | Doit être **non défini ou `false`** en prod | (ne pas définir) |
+
+Modèle annoté complet : [`.env.production.example`](../.env.production.example).
+
+> **Attention :** ne committez jamais de secrets sur GitHub. Vercel chiffre les variables d'environnement.
+
+Cliquez **Deploy**.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Étape 6 — Schéma initial et seed
+
+Le premier déploiement démarre l'app, mais la base est vide.
+
+### 6.1 Pousser le schéma
+
+Depuis votre poste :
+
+```bash
+git clone https://github.com/VOTRE-ORG/HaitiCityPortal.git
+cd HaitiCityPortal
+npm install
+echo 'DATABASE_URL="<votre chaîne Neon>"' > .env.local
+npm run db:push
+```
+
+### 6.2 Seed du premier tenant
+
+```bash
+$env:CONFIRM_PRODUCTION_SEED="yes"
+$env:SEED_ADMIN_EMAIL="admin@votre-domaine.ht"
+$env:SEED_ADMIN_PASSWORD="<mot de passe fort, unique>"
+$env:SEED_TENANT_NAME="Ville de Jacmel"
+$env:SEED_TENANT_SUBDOMAIN="jacmel"
+
+npm run db:seed:prod
+```
+
+(Sur macOS/Linux : `export VAR=valeur`.)
+
+Crée :
+- Une ligne `tenants` avec votre sous-domaine.
+- Une ligne `users` superadmin avec votre e-mail et mot de passe haché.
+
+Connexion ensuite à `https://jacmel.portal.ht/login` une fois le DNS résolu (étape 7).
+
+Pour ajouter d'autres communes plus tard : [Intégration d'une commune](TENANT_ONBOARDING.fr.md).
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Étape 7 — Connecter le domaine à Vercel
+
+Dans Vercel :
+
+1. **Settings → Domains**.
+2. Ajoutez `portal.ht`.
+3. Ajoutez `*.portal.ht` (le wildcard).
+4. Vercel vérifie le DNS (étape 2) et émet les certificats SSL.
+
+Ensuite :
+- `https://portal.ht` → arrive sur l'app (configurable pour rediriger vers un tenant par défaut ou une page d'accueil).
+- `https://jacmel.portal.ht` → arrive sur votre tenant Jacmel.
+
+> **Apex domain :** si votre bureau ne supporte pas le CNAME à l'apex, utilisez les enregistrements A recommandés par Vercel. Cloudflare et Porkbun gèrent le CNAME-flattening.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Étape 8 — Vérifier le déploiement
+
+Liste de contrôle :
+
+- [ ] `https://portal.ht` répond.
+- [ ] `https://jacmel.portal.ht` répond.
+- [ ] `https://jacmel.portal.ht/api/health` retourne un OK.
+- [ ] Changement de langue : `/en/`, `/fr/`, `/ht/`, `/es/`.
+- [ ] Connexion à `/login` avec votre admin.
+- [ ] Accès à une page admin (`/admin`).
+- [ ] Cadenas HTTPS valide.
+
+En cas d'échec : [Dépannage](#dépannage).
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Étape 9 — Ajouter votre premier tenant
+
+Si vous avez seedé un tenant à l'étape 6, c'est fait. Passez à la saisie de données via l'admin — voir [Manuel d'administration](ADMIN_MANUAL.fr.md).
+
+Pour les communes suivantes : [Intégration d'une commune](TENANT_ONBOARDING.fr.md).
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Mettre à jour l'application
+
+Quand du nouveau code arrive en amont :
+
+1. Synchronisez votre fork : GitHub → votre fork → bouton **Sync fork**.
+2. Vercel redéploie automatiquement à chaque push sur `main`.
+3. Si un changement de schéma est inclus, lancez `npm run db:push` sur la prod (ou automatisez dans CI).
+
+Recommandé : un environnement `staging` Vercel avec une base Neon distincte, pour tester d'abord.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Sauvegardes et reprise
+
+| Risque | Atténuation |
+|---|---|
+| Perte de base | Snapshots automatiques Neon. Plans payants : 30 jours. |
+| Bug applicatif | Vercel garde tous les déploiements précédents. **Promote to Production** = rollback instantané. |
+| Détournement DNS | 2FA sur registrar et fournisseur DNS. |
+| Mot de passe admin perdu | Réinitialisation via Drizzle Studio ou re-seed. |
+| `AUTH_SECRET` perdu | Rotation = déconnexion de toutes les sessions. Conserver dans un gestionnaire de mots de passe. |
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Supervision et logs
+
+- **Logs Vercel** : Settings → Logs.
+- **Tableau Neon** : performance et stockage.
+- Optionnel : **Sentry** pour le suivi d'erreurs applicatives.
+- Optionnel : **Better Stack / Pingdom** sur `/api/health` pour la disponibilité.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Récapitulatif des coûts
+
+| Composant | Gratuit | Standard payant |
+|---|---|---|
+| Vercel | 0 $ | 20 $/utilisateur/mois (Pro) |
+| Neon | 0 $ | 19 $/mois (Launch) |
+| Cloudflare DNS | 0 $ | 0 $ |
+| Domaine `.ht` | n/a | ~30 $/an |
+| Total | **~0 $/mois + 30 $/an** | **~40 $/mois + 30 $/an** |
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Plateformes alternatives
+
+C'est du Next.js 15 standard ; tourne partout où Node.js tourne.
+
+| Alternative | Notes |
+|---|---|
+| VPS auto-hébergé (Hetzner, Linode, OVH) | Docker ; ~5–20 $/mois ; vous gérez SSL et sauvegardes |
+| Cloudflare Pages + Workers | Possible avec adaptateurs ; certaines fonctions Next.js limitées |
+| Fly.io | Bon pour Postgres + Next.js auto-hébergés |
+| Railway | Expérience proche de Vercel |
+| Render | Expérience proche de Vercel |
+| AWS, GCP, Azure | Possible mais lourd ; déconseillé pour un premier déploiement |
+
+Auto-hébergement : à votre charge SSL, certificats wildcard, gestion de processus, sauvegardes Postgres.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Dépannage
+
+### Le sous-domaine renvoie « 404 Not Found »
+- Vérifiez que le CNAME wildcard existe.
+- Vérifiez que `*.portal.ht` est bien dans Vercel **Settings → Domains**.
+- L'émission SSL Vercel peut prendre 1–10 minutes la première fois.
+
+### « DB unavailable, using fallback tenant »
+- `DATABASE_URL` manquante ou erronée.
+- Base Neon en pause (free tier auto-pause après 5 minutes).
+- Chaîne de connexion sans `?sslmode=require`.
+
+### « MISSING_MESSAGE » ou « FORMATTING_ERROR »
+- Une clé manque dans un `messages/{locale}.json`. Vérifiez la parité des clés.
+
+### Boucle de redirection à la connexion
+- `NEXTAUTH_URL` ne correspond pas à l'URL réelle.
+- `AUTH_SECRET` non défini ou < 32 caractères.
+- `AUTH_TRUST_HOST` pas à `true`.
+
+### `npm run db:push` échoue
+- Testez la connexion `psql` d'abord.
+- Région du projet Neon correcte.
+
+### Échec build Vercel au premier déploiement
+- Vérifiez les variables manquantes dans le log de build.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+[← Index de la documentation](README.fr.md) · [Pour les municipalités](FOR_MUNICIPALITIES.fr.md) · [Intégration d'une commune →](TENANT_ONBOARDING.fr.md)

--- a/docs/DEPLOYMENT.ht.md
+++ b/docs/DEPLOYMENT.ht.md
@@ -1,0 +1,381 @@
+<!--
+Lang yo: English (DEPLOYMENT.md) | Français (DEPLOYMENT.fr.md) | Kreyòl (fichye sa a) | Español (DEPLOYMENT.es.md)
+-->
+
+**Lang yo:** [English](DEPLOYMENT.md) · [Français](DEPLOYMENT.fr.md) · **Kreyòl Ayisyen** · [Español](DEPLOYMENT.es.md)
+
+[← Endèks dokimantasyon](README.ht.md) · [README pwojè a](../README.md) · [Glosè](GLOSSARY.ht.md)
+
+---
+
+# Deplwaman
+
+Gid etap pa etap pou deplwaye Haiti City Portal an pwodiksyon. Dokiman sa fèt pou devlopè oswa lidè IT k ap opere sèvis an liy lan.
+
+## Tablo Kontni
+
+- [Prerequi](#prerequi)
+- [Apèsi achitekti](#apèsi-achitekti)
+- [Etap 1 — Domèn](#etap-1--domèn)
+- [Etap 2 — DNS wildcard](#etap-2--dns-wildcard)
+- [Etap 3 — Baz done (Neon)](#etap-3--baz-done-neon)
+- [Etap 4 — Ebèjman (Vercel)](#etap-4--ebèjman-vercel)
+- [Etap 5 — Varyab anviwònman](#etap-5--varyab-anviwònman)
+- [Etap 6 — Schema inisyal ak seed](#etap-6--schema-inisyal-ak-seed)
+- [Etap 7 — Konekte domèn ak Vercel](#etap-7--konekte-domèn-ak-vercel)
+- [Etap 8 — Verifye deplwaman an](#etap-8--verifye-deplwaman-an)
+- [Etap 9 — Ajoute premye tenant ou](#etap-9--ajoute-premye-tenant-ou)
+- [Mete aplikasyon an ajou](#mete-aplikasyon-an-ajou)
+- [Backup ak rekiperasyon](#backup-ak-rekiperasyon)
+- [Siveyans ak log](#siveyans-ak-log)
+- [Rezime pri](#rezime-pri)
+- [Lòt platfòm](#lòt-platfòm)
+- [Rezolisyon pwoblèm](#rezolisyon-pwoblèm)
+
+---
+
+## Prerequi
+
+Sou òdinatè w:
+
+- [Node.js 20+](https://nodejs.org/)
+- [Git](https://git-scm.com/)
+- [GitHub CLI](https://cli.github.com/) (`gh`) — opsyonèl
+- Yon editè kòd (VS Code, Cursor)
+
+Kont ou bezwen:
+
+- [GitHub](https://github.com) — pou fork depo a
+- Yon biwo enskripsyon domèn (Namecheap, Cloudflare, Porkbun…)
+- [Vercel](https://vercel.com) — ebèjman
+- [Neon](https://neon.tech) — baz PostgreSQL
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Apèsi achitekti
+
+An pwodiksyon:
+
+```
+        Entènèt
+           │
+           ▼
+   ┌───────────────┐       (chak komin gen pwòp soudomèn)
+   │ Cloudflare /  │       egz.  jacmel.portal.ht
+   │  biwo DNS     │             cap.portal.ht
+   │  *.portal.ht  │             demo.portal.ht
+   └───────┬───────┘
+           │
+           ▼
+   ┌───────────────┐       App Next.js:
+   │    Vercel     │       - middleware li Host → tenant
+   │  (Next.js 15) │       - server components rekèt BD
+   └───────┬───────┘       - HTTPS otomatik
+           │
+           ▼
+   ┌───────────────┐       Postgres 16:
+   │     Neon      │       - yon baz pataje
+   │  (PostgreSQL) │       - liy filtre pa tenant_id
+   └───────────────┘
+```
+
+Wè [Achitekti](ARCHITECTURE.ht.md) pou dyagram konplè.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Etap 1 — Domèn
+
+Yon sèl domèn pou tout komin pataje kòm soudomèn.
+
+Rekòmande: yon `.ht` pou idantite ayisyen, men nenpòt TLD mache.
+
+| Biwo | Nòt |
+|---|---|
+| Cloudflare | Renouvèlman pi bon mache, DNS ekselan, SSL gratis |
+| Namecheap | Entèfas senp, bon sipò |
+| Porkbun | Bon mache, modèn |
+
+Apre acha, **mete nameservers domèn ou pwente sou Cloudflare** si w te achte yon lòt kote.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Etap 2 — DNS wildcard
+
+Multi-tenant egzije yon wildcard DNS.
+
+Sou founisè DNS ou (Cloudflare isit la), ajoute **de CNAME**:
+
+| Tip | Non | Sib | Proxy |
+|---|---|---|---|
+| CNAME | `@` (apèks) | `cname.vercel-dns.com` | DNS only (nyaj gri) |
+| CNAME | `*` | `cname.vercel-dns.com` | DNS only (nyaj gri) |
+
+`*` la pèmèt `jacmel.portal.ht`, `cap.portal.ht`, ak nenpòt komin nan tan kap vini rezoud otomatikman.
+
+> **Enpòtan:** sou Cloudflare, mete antre yo nan « DNS only » (nyaj gri) okòmansman. Vercel dwe bay sètifika SSL pou chak soudomèn.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Etap 3 — Baz done (Neon)
+
+1. Konekte sou [neon.tech](https://neon.tech).
+2. Kreye yon **Pwojè** `haiti-city-portal-prod`.
+3. Chwazi rejyon ki pi pre: **AWS US East 2 (Ohio)** oswa **US East 1 (Vijini)**.
+4. Kopye **chèn koneksyon** an:
+   ```
+   postgresql://USER:PASSWORD@ep-xxx.us-east-2.aws.neon.tech/neondb?sslmode=require
+   ```
+5. Sa va vin varyab `DATABASE_URL` nan etap 5.
+
+> **Konsèy:** plan gratis Neon jenere. Kòmanse gratis epi monte sou plan « Launch » (~$19/mwa) lè itilizasyon ap monte.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Etap 4 — Ebèjman (Vercel)
+
+### 4.1 Fork depo a
+
+1. Ale sou [github.com/haitiansintech/HaitiCityPortal](https://github.com/haitiansintech/HaitiCityPortal).
+2. Klike **Fork** anwo adwat.
+3. (Opsyonèl) Chanje non fork ou (`mairie-jacmel-portal`).
+
+### 4.2 Enpòte nan Vercel
+
+1. Konekte sou [vercel.com](https://vercel.com) ak GitHub.
+2. **Add New… → Project**.
+3. Chwazi fork ou.
+4. **Framework preset**: Next.js (otomatik).
+5. **Root directory**: default.
+6. **Build & output settings**: default.
+7. **Pa klike Deploy** kounye a — ajoute varyab yo dabò (etap 5).
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Etap 5 — Varyab anviwònman
+
+Nan paramèt Vercel:
+
+| Varyab | Bezwen? | Egzanp |
+|---|---|---|
+| `DATABASE_URL` | **Wi** | `postgresql://USER:PASS@ep-xxx.us-east-2.aws.neon.tech/neondb?sslmode=require` |
+| `AUTH_SECRET` | **Wi** | Chèn aleatwa 32+ karaktè. `openssl rand -base64 32` |
+| `NEXTAUTH_URL` | **Wi** | `https://portal.ht` |
+| `AUTH_TRUST_HOST` | Rekòmande | `true` |
+| `NEXT_PUBLIC_BASE_URL` | Opsyonèl | `https://portal.ht` |
+| `ENABLE_LOCAL_MODE` | Dwe **pa defini oswa `false`** an pwodiksyon | (pa defini) |
+
+Modèl konplè ak kòmantè: [`.env.production.example`](../.env.production.example).
+
+> **Atansyon:** pa janm commit sekrè sou GitHub. Vercel kripte varyab anviwònman.
+
+Klike **Deploy**.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Etap 6 — Schema inisyal ak seed
+
+Premye deplwaman lanse app la, men baz la vid.
+
+### 6.1 Pouse schema a
+
+Soti sou òdinatè w:
+
+```bash
+git clone https://github.com/OU-ORG/HaitiCityPortal.git
+cd HaitiCityPortal
+npm install
+echo 'DATABASE_URL="<chèn Neon ou>"' > .env.local
+npm run db:push
+```
+
+### 6.2 Seed premye tenant
+
+```bash
+$env:CONFIRM_PRODUCTION_SEED="yes"
+$env:SEED_ADMIN_EMAIL="admin@domèn-ou.ht"
+$env:SEED_ADMIN_PASSWORD="<modpas fò, inik>"
+$env:SEED_TENANT_NAME="Vil Jakmèl"
+$env:SEED_TENANT_SUBDOMAIN="jacmel"
+
+npm run db:seed:prod
+```
+
+(Sou macOS/Linux: `export VAR=valè`.)
+
+Sa kreye:
+- Yon liy `tenants` ak soudomèn ou chwazi.
+- Yon liy `users` superadmin ak imèl ou ak modpas hash.
+
+Konekte apre sou `https://jacmel.portal.ht/login` lè DNS rezoud (etap 7).
+
+Pou ajoute lòt komin: [Mete yon Vil Anplas](TENANT_ONBOARDING.ht.md).
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Etap 7 — Konekte domèn ak Vercel
+
+Nan Vercel:
+
+1. **Settings → Domains**.
+2. Ajoute `portal.ht`.
+3. Ajoute `*.portal.ht` (wildcard la).
+4. Vercel verifye DNS la (etap 2) epi bay sètifika SSL otomatikman.
+
+Apre:
+- `https://portal.ht` → rive nan app la.
+- `https://jacmel.portal.ht` → rive nan tenant Jacmel ou.
+
+> **Apèks domèn:** si biwo w pa sipòte CNAME nan apèks la, itilize antre A Vercel rekòmande. Cloudflare ak Porkbun jere CNAME-flattening.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Etap 8 — Verifye deplwaman an
+
+Lis verifikasyon:
+
+- [ ] `https://portal.ht` reponn.
+- [ ] `https://jacmel.portal.ht` reponn.
+- [ ] `https://jacmel.portal.ht/api/health` retounen OK.
+- [ ] Chanjman lang: `/en/`, `/fr/`, `/ht/`, `/es/`.
+- [ ] Konekte sou `/login` ak admin ou.
+- [ ] Aksè a yon paj admin (`/admin`).
+- [ ] Ikon kadna HTTPS valid.
+
+Si yon bagay echwe: [Rezolisyon pwoblèm](#rezolisyon-pwoblèm).
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Etap 9 — Ajoute premye tenant ou
+
+Si ou seedè yon tenant nan etap 6, sa fini. Pase pou antre done atravè admin — wè [Manyèl Administrasyon](ADMIN_MANUAL.ht.md).
+
+Pou pwochèn komin: [Mete yon Vil Anplas](TENANT_ONBOARDING.ht.md).
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Mete aplikasyon an ajou
+
+Lè kòd nouvo soti anwo:
+
+1. Senkronize fork ou: GitHub → fork ou → bouton **Sync fork**.
+2. Vercel redeplwaye otomatikman sou chak push sou `main`.
+3. Si gen chanjman schema, lanse `npm run db:push` sou prod (oswa otomatize nan CI).
+
+Rekòmande: yon anviwònman `staging` Vercel ak yon baz Neon distenk pou tès anvan.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Backup ak rekiperasyon
+
+| Risk | Solisyon |
+|---|---|
+| Pèdi baz | Snapshot otomatik Neon. Plan peye: 30 jou. |
+| Bug app | Vercel kenbe tout deplwaman anvan yo. **Promote to Production** = rollback enstantane. |
+| DNS pirate | 2FA sou registrar ak founisè DNS. |
+| Modpas admin pèdi | Reseti atravè Drizzle Studio oswa re-seed. |
+| `AUTH_SECRET` pèdi | Wotasyon = dekonekte tout sesyon. Konsève nan jesyonè modpas. |
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Siveyans ak log
+
+- **Logs Vercel**: Settings → Logs.
+- **Tablo Neon**: pèfòmans ak depo.
+- Opsyonèl: **Sentry** pou erè aplikasyon.
+- Opsyonèl: **Better Stack / Pingdom** sou `/api/health` pou disponiblite.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Rezime pri
+
+| Eleman | Gratis | Standar peye |
+|---|---|---|
+| Vercel | $0 | $20/itilizatè/mwa (Pro) |
+| Neon | $0 | $19/mwa (Launch) |
+| Cloudflare DNS | $0 | $0 |
+| Domèn `.ht` | n/a | ~$30/ane |
+| Total | **~$0/mwa + $30/ane** | **~$40/mwa + $30/ane** |
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Lòt platfòm
+
+Se Next.js 15 estanda; mache nenpòt kote Node.js mache.
+
+| Altènatif | Nòt |
+|---|---|
+| VPS oto-ebèje (Hetzner, Linode, OVH) | Docker; ~$5–20/mwa; ou jere SSL ak backup |
+| Cloudflare Pages + Workers | Posib ak adaptè; kèk fonksyon Next.js limite |
+| Fly.io | Bon pou Postgres + Next.js oto-ebèje |
+| Railway | Eksperyans menm jan ak Vercel |
+| Render | Eksperyans menm jan ak Vercel |
+| AWS, GCP, Azure | Posib men lou; pa rekòmande pou premye deplwaman |
+
+Oto-ebèjman: ou responsab pou SSL, sètifika wildcard, jesyon pwosesis, backup Postgres.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Rezolisyon pwoblèm
+
+### Soudomèn retounen « 404 Not Found »
+- Verifye CNAME wildcard egziste.
+- Verifye `*.portal.ht` byen mete nan Vercel **Settings → Domains**.
+- Bay SSL Vercel ka pran 1–10 minit premye fwa a.
+
+### « DB unavailable, using fallback tenant »
+- `DATABASE_URL` manke oswa pa kòrèk.
+- Baz Neon an pòz (free tier auto-pause apre 5 minit).
+- Chèn koneksyon san `?sslmode=require`.
+
+### « MISSING_MESSAGE » oswa « FORMATTING_ERROR »
+- Yon kle manke nan `messages/{locale}.json`. Verifye paritè kle yo.
+
+### Bouk redireksyon nan koneksyon
+- `NEXTAUTH_URL` pa matche URL reyèl la.
+- `AUTH_SECRET` pa defini oswa < 32 karaktè.
+- `AUTH_TRUST_HOST` pa `true`.
+
+### `npm run db:push` echwe
+- Teste koneksyon `psql` an premye.
+- Verifye rejyon pwojè Neon kòrèk.
+
+### Build Vercel echwe nan premye deplwaman
+- Verifye varyab manke nan log build.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+[← Endèks dokimantasyon](README.ht.md) · [Pou minisipalite](FOR_MUNICIPALITIES.ht.md) · [Mete yon Vil Anplas →](TENANT_ONBOARDING.ht.md)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,396 @@
+<!--
+Languages: English (this file) | Français (DEPLOYMENT.fr.md) | Kreyòl (DEPLOYMENT.ht.md) | Español (DEPLOYMENT.es.md)
+-->
+
+**Languages:** **English** · [Français](DEPLOYMENT.fr.md) · [Kreyòl Ayisyen](DEPLOYMENT.ht.md) · [Español](DEPLOYMENT.es.md)
+
+[← Docs index](README.md) · [Project README](../README.md) · [Glossary](GLOSSARY.md)
+
+---
+
+# Deployment
+
+Step-by-step guide to deploying Haiti City Portal in production. This document is written for the developer or IT lead who will operate the live service.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Architecture overview](#architecture-overview)
+- [Step 1 — Domain](#step-1--domain)
+- [Step 2 — Wildcard DNS](#step-2--wildcard-dns)
+- [Step 3 — Database (Neon)](#step-3--database-neon)
+- [Step 4 — Hosting (Vercel)](#step-4--hosting-vercel)
+- [Step 5 — Environment variables](#step-5--environment-variables)
+- [Step 6 — Initial schema and seed](#step-6--initial-schema-and-seed)
+- [Step 7 — Connect domain to Vercel](#step-7--connect-domain-to-vercel)
+- [Step 8 — Verify the deployment](#step-8--verify-the-deployment)
+- [Step 9 — Add your first tenant](#step-9--add-your-first-tenant)
+- [Updating the application](#updating-the-application)
+- [Backups and disaster recovery](#backups-and-disaster-recovery)
+- [Monitoring and logs](#monitoring-and-logs)
+- [Cost summary](#cost-summary)
+- [Alternative platforms](#alternative-platforms)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Prerequisites
+
+Install on your laptop:
+
+- [Node.js 20+](https://nodejs.org/)
+- [Git](https://git-scm.com/)
+- [GitHub CLI](https://cli.github.com/) (`gh`) — optional but useful
+- A code editor (VS Code, Cursor, etc.)
+
+You'll also need accounts at:
+
+- [GitHub](https://github.com) (free) — to fork the repo
+- A domain registrar (any: [Namecheap](https://www.namecheap.com/), [Cloudflare](https://www.cloudflare.com/), [Porkbun](https://porkbun.com/), etc.)
+- [Vercel](https://vercel.com) (free tier available) — hosting
+- [Neon](https://neon.tech) (free tier available) — PostgreSQL database
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Architecture overview
+
+In production, the system looks like this:
+
+```
+        Internet
+           │
+           ▼
+   ┌───────────────┐       (each commune has its own subdomain)
+   │   Cloudflare/ │       e.g.  jacmel.portal.ht
+   │   Registrar   │             cap.portal.ht
+   │   wildcard DNS│             demo.portal.ht
+   │   *.portal.ht │
+   └───────┬───────┘
+           │
+           ▼
+   ┌───────────────┐       Next.js app:
+   │    Vercel     │       - middleware reads Host → tenant
+   │  (Next.js 15) │       - server components query DB
+   └───────┬───────┘       - HTTPS handled automatically
+           │
+           ▼
+   ┌───────────────┐       Postgres 16:
+   │     Neon      │       - one shared database
+   │  (PostgreSQL) │       - rows scoped by tenant_id
+   └───────────────┘
+```
+
+See [Architecture](ARCHITECTURE.md) for the full diagram.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Step 1 — Domain
+
+You need a single domain that all communes will share as subdomains.
+
+Recommended: a `.ht` domain so it reads as Haitian, but any TLD works (`.org`, `.com`, etc.).
+
+| Registrar | Notes |
+|---|---|
+| Cloudflare | Cheapest renewals, excellent DNS, free SSL |
+| Namecheap | Easy interface, good support |
+| Porkbun | Cheap, modern interface |
+
+After purchase, **point your domain's nameservers to Cloudflare** if you bought elsewhere — Cloudflare's DNS is the easiest for wildcard records and is free.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Step 2 — Wildcard DNS
+
+Multi-tenancy depends on a wildcard DNS record. Without it, you cannot serve multiple cities.
+
+In your DNS provider (Cloudflare in this guide), add **two CNAME records**:
+
+| Type | Name | Target | Proxy |
+|---|---|---|---|
+| CNAME | `@` (or your apex) | `cname.vercel-dns.com` | DNS only (grey cloud) |
+| CNAME | `*` | `cname.vercel-dns.com` | DNS only (grey cloud) |
+
+The `*` record is what makes `jacmel.portal.ht`, `cap.portal.ht`, and any future commune resolve automatically.
+
+> **Important:** if you use Cloudflare, set the records to "DNS only" (grey cloud icon), not "proxied" (orange cloud), at first. Vercel needs to issue SSL certificates for each subdomain, and Cloudflare's proxy can interfere. You can re-enable proxying later for caching.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Step 3 — Database (Neon)
+
+1. Sign in at [neon.tech](https://neon.tech).
+2. Create a new **Project** named `haiti-city-portal-prod`.
+3. Pick the region closest to your users. For Haiti, **AWS US East 2 (Ohio)** or **US East 1 (N. Virginia)** are good choices.
+4. After creation, copy the **connection string** that looks like:
+   ```
+   postgresql://USER:PASSWORD@ep-xxx.us-east-2.aws.neon.tech/neondb?sslmode=require
+   ```
+5. Save this — it becomes the `DATABASE_URL` environment variable in Step 5.
+
+> **Tip:** Neon's free tier is generous. You can start free and upgrade only when usage grows. The "Launch" plan (around $19/month) gives you autoscaling and a longer storage retention window.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Step 4 — Hosting (Vercel)
+
+### 4.1 Fork the repository
+
+1. Visit [github.com/haitiansintech/HaitiCityPortal](https://github.com/haitiansintech/HaitiCityPortal).
+2. Click **Fork** in the upper right.
+3. (Optional) Rename your fork to something organisation-specific, e.g. `mairie-jacmel-portal`.
+
+### 4.2 Import into Vercel
+
+1. Sign in at [vercel.com](https://vercel.com) with your GitHub account.
+2. Click **Add New… → Project**.
+3. Select your fork.
+4. **Framework preset**: Next.js (auto-detected).
+5. **Root directory**: leave default.
+6. **Build & output settings**: leave default.
+7. Do **not** click **Deploy** yet — first add the environment variables (Step 5).
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Step 5 — Environment variables
+
+In the Vercel project settings (or during the import wizard), add these:
+
+| Variable | Required? | Example value |
+|---|---|---|
+| `DATABASE_URL` | **Yes** | `postgresql://USER:PASS@ep-xxx.us-east-2.aws.neon.tech/neondb?sslmode=require` |
+| `AUTH_SECRET` | **Yes** | A random 32+ char string. Generate with `openssl rand -base64 32` |
+| `NEXTAUTH_URL` | **Yes** | `https://portal.ht` (your apex domain, with `https://`) |
+| `AUTH_TRUST_HOST` | Recommended | `true` (Vercel sits behind a proxy) |
+| `NEXT_PUBLIC_BASE_URL` | Optional | `https://portal.ht` |
+| `ENABLE_LOCAL_MODE` | Must be **unset or `false`** in production | (do not set) |
+
+A complete annotated template is provided in [`.env.production.example`](../.env.production.example).
+
+> **Warning:** Never commit secrets to GitHub. Vercel encrypts environment variables at rest and they are only exposed to the running app.
+
+Click **Deploy**.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Step 6 — Initial schema and seed
+
+The very first deploy starts the app, but the database is empty. You need to push the schema and seed your first tenant.
+
+### 6.1 Push the schema
+
+From your laptop:
+
+```bash
+git clone https://github.com/YOUR-ORG/HaitiCityPortal.git
+cd HaitiCityPortal
+npm install
+echo 'DATABASE_URL="<your Neon connection string>"' > .env.local
+npm run db:push
+```
+
+This creates every table defined in `src/db/schema.ts` in your Neon database.
+
+### 6.2 Seed your first tenant
+
+The repo ships with a production-safe seed script that requires explicit confirmation. From your laptop, with the production `DATABASE_URL` already in `.env.local`:
+
+```bash
+# These four are required by src/db/seed.production.ts
+$env:CONFIRM_PRODUCTION_SEED="yes"
+$env:SEED_ADMIN_EMAIL="admin@yourdomain.ht"
+$env:SEED_ADMIN_PASSWORD="<a strong, unique password>"
+$env:SEED_TENANT_NAME="Ville de Jacmel"
+$env:SEED_TENANT_SUBDOMAIN="jacmel"
+
+npm run db:seed:prod
+```
+
+(On macOS/Linux, use `export VAR=value` instead of `$env:VAR=`.)
+
+This creates:
+- One `tenants` row with the subdomain you chose.
+- One `users` row with the admin email and a hashed password — your initial superadmin.
+
+You can now sign in at `https://jacmel.portal.ht/login` once DNS resolves (Step 7).
+
+For onboarding additional cities later, see [Tenant Onboarding](TENANT_ONBOARDING.md).
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Step 7 — Connect domain to Vercel
+
+In the Vercel project settings:
+
+1. Open **Settings → Domains**.
+2. Add `portal.ht` (your apex domain).
+3. Add `*.portal.ht` (the wildcard — this is how every commune subdomain works).
+4. Vercel will verify the DNS records you set in Step 2 and issue SSL certificates automatically.
+
+Once verified, both:
+- `https://portal.ht` → reaches the app (you can configure this to redirect to a default tenant or a public landing page).
+- `https://jacmel.portal.ht` → reaches your Jacmel tenant (the one you seeded).
+
+> **Note on apex domains:** If your registrar doesn't support CNAME at the apex (some don't), use Vercel's recommended A records instead. Cloudflare and Porkbun support CNAME-flattening so this is a non-issue there.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Step 8 — Verify the deployment
+
+Run this checklist:
+
+- [ ] `https://portal.ht` returns a page.
+- [ ] `https://jacmel.portal.ht` (or your subdomain) returns a page.
+- [ ] `https://jacmel.portal.ht/api/health` returns `{"status":"ok"}` or similar.
+- [ ] You can switch languages: `/en/`, `/fr/`, `/ht/`, `/es/`.
+- [ ] You can sign in at `/login` with the admin credentials you seeded.
+- [ ] You can access an admin page (e.g. `/admin`).
+- [ ] The browser shows a valid lock/HTTPS icon.
+
+If any item fails, see [Troubleshooting](#troubleshooting).
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Step 9 — Add your first tenant
+
+If you seeded one tenant in Step 6, that's your "first tenant". You can stop here and proceed to filling in your commune's data through the admin panel — see [Admin Manual](ADMIN_MANUAL.md).
+
+To add **additional** communes (a second city, a third, etc.), see [Tenant Onboarding](TENANT_ONBOARDING.md).
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Updating the application
+
+When new code lands in the upstream repository:
+
+1. Sync your fork: GitHub → your fork → **Sync fork** button.
+2. Vercel auto-deploys from your fork's `main` branch on every push.
+3. If a database schema change is included, run `npm run db:push` against your production database (or set up an automated migration step in CI).
+
+Recommended: set up a `staging` environment in Vercel that mirrors production but uses a separate Neon database. Test schema changes there first.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Backups and disaster recovery
+
+| Concern | Mitigation |
+|---|---|
+| Database loss | Neon takes automatic point-in-time snapshots. Paid plans extend retention to 30 days. |
+| Application bug | Vercel keeps every previous deployment. **Settings → Deployments → Promote to Production** rolls back instantly. |
+| DNS hijack | Enable two-factor authentication on your registrar and DNS provider. |
+| Lost admin password | Run a Drizzle Studio query to reset the hashed password, or re-run the seed with new credentials. |
+| Lost `AUTH_SECRET` | Rotating this signs out every active session — not catastrophic. Keep it in a password manager nonetheless. |
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Monitoring and logs
+
+- **Vercel logs**: Settings → Logs → Runtime Logs. See request-level errors.
+- **Neon dashboard**: Monitor query performance and storage.
+- **Optional: Sentry** for application error tracking.
+- **Optional: Better Stack / Pingdom** for uptime monitoring (the `/api/health` endpoint is built for this).
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Cost summary
+
+| Component | Free tier | Standard paid tier |
+|---|---|---|
+| Vercel | $0 | $20/user/month (Pro) |
+| Neon | $0 | $19/month (Launch) |
+| Cloudflare DNS | $0 | $0 (DNS is free) |
+| Domain (`.ht`) | n/a | ~$30/year |
+| Total | **~$0/month + $30/year** | **~$40/month + $30/year** |
+
+You can launch on the free tier and upgrade as usage grows.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Alternative platforms
+
+The project is standard Next.js 15 — it runs anywhere Node.js runs.
+
+| Alternative | Notes |
+|---|---|
+| Self-hosted on a VPS (Hetzner, Linode, OVH) | Use Docker; ~$5–20/month; you handle SSL, scaling, backups |
+| Cloudflare Pages + Workers | Possible with adapters; some Next.js features may not work |
+| Fly.io | Good for self-hosted Postgres + Next.js together |
+| Railway | Similar developer experience to Vercel |
+| Render | Similar developer experience to Vercel |
+| AWS, GCP, Azure | Possible but significant setup; not recommended for first deploy |
+
+If you choose self-hosting, you must also handle:
+- HTTPS (Let's Encrypt + a reverse proxy like Caddy or Traefik)
+- Wildcard certificate issuance for `*.portal.ht`
+- Process management (systemd or Docker)
+- Backups for Postgres
+
+For most communes, Vercel + Neon is dramatically cheaper in staff time.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Troubleshooting
+
+### Subdomain returns "404 Not Found"
+- Check the wildcard CNAME exists.
+- Check the wildcard domain is added in Vercel **Settings → Domains** (the `*.portal.ht` entry).
+- Vercel's SSL provisioning can take 1–10 minutes the first time.
+
+### "DB unavailable, using fallback tenant"
+- `DATABASE_URL` is missing or wrong in Vercel env vars.
+- The Neon database has been suspended (free tier auto-suspends after 5 minutes of inactivity — first request may be slow).
+- The Neon connection string is missing `?sslmode=require`.
+
+### "MISSING_MESSAGE" or "FORMATTING_ERROR" in the UI
+- A `messages/{locale}.json` key is missing. Check that all four locale files have parallel keys.
+
+### Login redirects in a loop
+- `NEXTAUTH_URL` does not match the actual deployment URL.
+- `AUTH_SECRET` is not set or is shorter than 32 characters.
+- `AUTH_TRUST_HOST` is not `true`.
+
+### `npm run db:push` fails
+- Confirm `DATABASE_URL` in `.env.local` is reachable. Try connecting with `psql` first.
+- Check that your Neon project is in the same region you specified.
+
+### Vercel build fails on first deploy
+- Check the build log for missing env vars.
+- React 19 RC + Tailwind v4 alpha require `--legacy-peer-deps` on `npm install` in older npm versions; Vercel's modern builds usually handle this fine.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+[← Docs index](README.md) · [For Municipalities](FOR_MUNICIPALITIES.md) · [Tenant Onboarding →](TENANT_ONBOARDING.md)

--- a/docs/FOR_MUNICIPALITIES.es.md
+++ b/docs/FOR_MUNICIPALITIES.es.md
@@ -1,0 +1,263 @@
+<!--
+Idiomas: English (FOR_MUNICIPALITIES.md) | Français (FOR_MUNICIPALITIES.fr.md) | Kreyòl (FOR_MUNICIPALITIES.ht.md) | Español (este archivo)
+-->
+
+**Idiomas:** [English](FOR_MUNICIPALITIES.md) · [Français](FOR_MUNICIPALITIES.fr.md) · [Kreyòl Ayisyen](FOR_MUNICIPALITIES.ht.md) · **Español**
+
+[← Índice de documentación](README.es.md) · [README del proyecto](../README.md) · [Glosario](GLOSSARY.es.md)
+
+---
+
+# Para Municipalidades
+
+Guía no técnica para alcaldes, concejales y personal municipal que evalúan Haiti City Portal para su comuna.
+
+## Índice
+
+- [¿Qué es Haiti City Portal?](#qué-es-haiti-city-portal)
+- [¿Qué pueden hacer sus residentes?](#qué-pueden-hacer-sus-residentes)
+- [¿Qué puede hacer su personal?](#qué-puede-hacer-su-personal)
+- [Lo que necesita para correrlo](#lo-que-necesita-para-correrlo)
+- [Costos estimados](#costos-estimados)
+- [Tiempo para lanzar](#tiempo-para-lanzar)
+- [Roles requeridos en su lado](#roles-requeridos-en-su-lado)
+- [Idiomas y accesibilidad](#idiomas-y-accesibilidad)
+- [Datos, propiedad y privacidad](#datos-propiedad-y-privacidad)
+- [Preguntas frecuentes](#preguntas-frecuentes)
+- [Cómo empezar](#cómo-empezar)
+- [A quién contactar](#a-quién-contactar)
+
+---
+
+## ¿Qué es Haiti City Portal?
+
+Haiti City Portal es **software libre y gratuito** para comunas haitianas. Le da a sus residentes un sitio web único donde pueden:
+
+- Consultar información sobre servicios municipales
+- Enviar solicitudes y reportar problemas (baches, basura, alumbrado)
+- Pagar tasas municipales por MonCash o transferencia bancaria
+- Leer noticias oficiales y alertas de emergencia
+- Encontrar hospitales, escuelas y comisarías
+- Ver oficiales electos y contactarlos
+
+También entrega a su personal un panel de administración para gestionar solicitudes, verificar pagos, publicar noticias y emitir alertas.
+
+Está construido para que **un mismo sistema compartido pueda servir a cualquier número de comunas**. Cada comuna tiene su propio subdominio (ej. `jacmel.portal.ht`, `cap.portal.ht`) y sus propios datos — totalmente separados de las demás.
+
+> **En una frase:** es el mismo tipo de sistema que usan ciudades como Boston o Lyon, pero diseñado específicamente para Haití — multilingüe por defecto, listo para conexiones lentas y adaptado a realidades locales (CASEC, ASEC, MonCash, NIF).
+
+[↑ Volver arriba](#índice)
+
+---
+
+## ¿Qué pueden hacer sus residentes?
+
+| Función ciudadana | Por qué importa |
+|---|---|
+| Encontrar un servicio y ver qué documentos se requieren | Reduce viajes innecesarios al ayuntamiento |
+| Reportar un problema con foto y GPS | Los problemas dejan de perderse |
+| Pagar en línea por MonCash o transferencia | Menos efectivo, menos filas |
+| Recibir un recibo digital (quittance) | Menos papel, menos fraude |
+| Ver todas las instalaciones públicas en un mapa | Ayuda más rápida en emergencias |
+| Leer noticias y alertas oficiales | Información oficial reemplaza el rumor |
+| Usar el sitio en criollo, francés, inglés o español | Acceso igualitario residentes y diáspora |
+| Ver oficiales por sección comunal | Mayor rendición de cuentas democrática |
+
+[↑ Volver arriba](#índice)
+
+---
+
+## ¿Qué puede hacer su personal?
+
+| Función admin | Quién la usa |
+|---|---|
+| Ver solicitudes entrantes y cambiar su estado | Personal de atención |
+| Verificar pagos pendientes contra extractos banco/MonCash | Oficial financiero |
+| Publicar artículos de noticias y alertas | Oficial de comunicaciones |
+| Gestionar la lista de oficiales y sus contactos | Jefe de gabinete del alcalde |
+| Mantener el directorio de instalaciones y sus GPS | Líder GIS / engagement cívico |
+| Ver tableros financieros y snapshots de auditoría | Alcalde / tesorero |
+| Leer y reconocer artículos del manual de gobernanza | Todos los admins |
+| Restringir quién hace qué (roles user/admin/superadmin) | TI / gabinete |
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Lo que necesita para correrlo
+
+Solo tres cosas:
+
+1. **Un nombre de dominio** — ejemplo `portal.ht` o el suyo (`jacmel-mairie.ht`). Aproximadamente $15–30 al año.
+2. **Una cuenta de hosting** — recomendado: [Vercel](https://vercel.com) (gratis para comunas pequeñas, $20–40/mes para mayores).
+3. **Una base PostgreSQL gestionada** — recomendado: [Neon](https://neon.tech) (gratis para comunas pequeñas, $19/mes el plan estándar pago).
+
+**No** necesita servidor físico, sala de servidores ni hardware especial. Todo corre en la nube.
+
+Con esos tres elementos, un desarrollador con experiencia puede desplegar el portal de su comuna **en menos de un día**.
+
+Vea el detalle en [Despliegue](DEPLOYMENT.es.md) y [Alta de Municipio](TENANT_ONBOARDING.es.md).
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Costos estimados
+
+Para una comuna de tamaño típico (50.000–200.000 habitantes):
+
+| Ítem | Costo mensual indicativo |
+|---|---|
+| Nombre de dominio | ~$2/mes (pagado anual) |
+| Hosting (Vercel) | $0–40 |
+| Base de datos (Neon) | $0–19 |
+| Servicio de email (opcional, ej. Resend) | $0–20 |
+| Tiles de mapas (gratis con MapLibre por defecto) | $0 |
+| **Total** | **~$20–80 / mes** |
+
+Estos números cubren solo infraestructura. **No incluyen** personas: un desarrollador para desplegar, un editor para traducir, un admin para verificar pagos. La mayoría de comunas cubre estos roles con personal existente.
+
+Una segunda, tercera o centésima comuna puede sumarse al mismo despliegue compartido a **costo adicional casi nulo**, gracias a la arquitectura multi-tenant.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Tiempo para lanzar
+
+Cronograma realista para una comuna:
+
+| Etapa | Tiempo | Quién |
+|---|---|---|
+| Comprar dominio, crear cuentas hosting | 1 día | TI o desarrollador |
+| Desplegar la aplicación | Medio día | Desarrollador |
+| Configurar subdominio y crear el tenant | 1 hora | Desarrollador |
+| Cargar oficiales, secciones, instalaciones | 1–3 días | Comunicaciones + registro |
+| Traducir o redactar descripciones de servicios | 1–2 semanas | Equipo de comunicaciones |
+| Capacitar al personal en el panel admin | Medio día | Gabinete |
+| Lanzamiento restringido | 1 día | Comunicaciones |
+| Lanzamiento público | 1 día | Gabinete del alcalde |
+
+**Total: 2–4 semanas desde la decisión hasta el lanzamiento público**, sujeto a disponibilidad del personal.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Roles requeridos en su lado
+
+| Rol | Tiempo necesario | Habilidades |
+|---|---|---|
+| **Sponsor** (alcalde o jefe de gabinete) | Pocas horas en total | Autoridad de decisión, priorización |
+| **Desarrollador / TI** | 2–5 días para setup, luego ocasional | Cómodo con Node.js, hosting web, DNS. Interno, voluntario o contratista. |
+| **Oficial de comunicaciones** | Continuo | Redacta noticias, traduce servicios, publica alertas. Sin código. |
+| **Oficial financiero** | Continuo | Verifica pagos contra extractos |
+| **Personal de atención** | Continuo | Lee solicitudes y cambia su estado |
+
+No necesita un equipo grande. Un miembro del personal con afinidad técnica más el equipo de comunicaciones del alcalde es suficiente para la mayoría de comunas.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Idiomas y accesibilidad
+
+El portal se entrega en cuatro idiomas:
+
+- **Criollo haitiano (Kreyòl Ayisyen)** — por defecto, lengua materna de la gran mayoría de haitianos.
+- **Francés** — lengua escrita oficial del gobierno.
+- **Inglés** — para diáspora, ONG y socios.
+- **Español** — accesibilidad transfronteriza (República Dominicana, socios regionales).
+
+Los residentes cambian de idioma arriba en cada página. Si un contenido aún no está traducido, el portal muestra automáticamente la versión en inglés — sin páginas rotas.
+
+El sitio está construido mobile-first, optimizado para conexiones lentas (2G/3G), y cumple con estándares de accesibilidad web habituales.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Datos, propiedad y privacidad
+
+- **Sus datos son suyos.** Los residentes, solicitudes, pagos, noticias y oficiales de su comuna se almacenan en *su* base. Otras comunas del despliegue compartido no pueden ver sus datos.
+- **El software es open source** bajo Business Source License 1.1. Cualquier comuna puede usarlo libremente para fines no comerciales. Pasa a Apache 2.0 (totalmente libre) el 31 de diciembre de 2028. Vea [LICENSE.md](../LICENSE.md).
+- **El aislamiento entre tenants se aplica a nivel de código.** Cada consulta filtra por `tenant_id`. Una fuga de datos entre comunas se trata como incidente de seguridad crítico.
+- **Las contraseñas están hasheadas.** Ni los mantenedores pueden leerlas.
+- **Sin tracking analítico por defecto.** Usted decide qué agrega.
+
+Detalles en [Política de Seguridad](../SECURITY.md).
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Preguntas frecuentes
+
+**P. ¿Hay que pagar por el software?**
+R. No. El código es gratis. Solo paga la infraestructura (dominio, hosting, base) y su personal.
+
+**P. No tenemos desarrollador. ¿Qué hacemos?**
+R. Tres opciones: (1) Pedir a una universidad local — muchos estudiantes de informática saltarían sobre este proyecto. (2) Contactar la red Haitians in Tech para un voluntario o contratista económico. (3) Escribir a `info@haiticity.org`; ayudamos a conectarlos.
+
+**P. ¿Podemos personalizar el sitio para nuestra comuna?**
+R. Sí — nombre, logo, colores, fotos oficiales, secciones comunales, servicios y noticias son todos configurables por comuna. La base gráfica se comparte para que todas las comunas se vean como una infraestructura cívica nacional.
+
+**P. ¿Podemos agregar un servicio propio de nuestra comuna?**
+R. Sí. Los servicios se definen en archivos de contenido que cualquiera puede editar. Vea [Guía de Contenido](CONTENT_GUIDE.es.md).
+
+**P. ¿Y si nuestra internet no es estable?**
+R. El sitio está optimizado para baja velocidad. El envío offline está en la hoja de ruta ([Estado de Implementación](v0.1-implementation-plan.md)).
+
+**P. ¿Si MonCash está caído?**
+R. La transferencia bancaria sirve de respaldo. El sistema emite un código memo que el residente incluye, y un admin verifica manualmente. La integración por webhook de MonCash está en la hoja de ruta.
+
+**P. Ya tenemos un sitio. ¿Por qué cambiar?**
+R. No tiene que cambiar. Puede correr el portal en un subdominio (`servicios.su-mairie.ht`) y enlazarlo desde su sitio. O usarlo como sitio principal. Su elección.
+
+**P. ¿Los residentes pueden crear cuenta?**
+R. Hoy pueden enviar solicitudes anónimamente. La creación de cuenta para residentes (seguir sus solicitudes) está en la hoja de ruta.
+
+**P. ¿Y la diáspora?**
+R. El portal es multilingüe (inglés/francés/español) y soporta transferencias internacionales para proyectos comunitarios. Stripe (USD/EUR) está en la hoja de ruta.
+
+**P. ¿Podemos integrar con sistemas existentes (ej. catastro)?**
+R. Sí. El portal expone APIs y puede extenderse. Hable con su desarrollador.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Cómo empezar
+
+1. Lea este documento y el [Glosario](GLOSSARY.es.md) — comparta ambos con quienes deciden.
+2. Identifique a su desarrollador / TI y comparta [Despliegue](DEPLOYMENT.es.md) y [Alta de Municipio](TENANT_ONBOARDING.es.md).
+3. Identifique al líder de contenido (comunicaciones) y comparta [Guía de Contenido](CONTENT_GUIDE.es.md).
+4. Decida un dominio (o subdominio).
+5. Cree las cuentas de hosting y base de datos.
+6. Despliegue.
+7. Dé de alta su tenant (cree su comuna en el sistema).
+8. Cargue oficiales, secciones, instalaciones, servicios, noticias.
+9. Capacite al personal con [Manual de Administración](ADMIN_MANUAL.es.md).
+10. Lance.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## A quién contactar
+
+| Motivo | Contacto |
+|---|---|
+| Preguntas generales | `info@haiticity.org` |
+| Encontrar desarrollador | `info@haiticity.org` |
+| Seguridad o vulnerabilidad | `security@haiticity.org` |
+| Licenciamiento para uso comercial | `licensing@haiticity.org` |
+| Bug o solicitud de feature | [Abrir un issue](https://github.com/haitiansintech/HaitiCityPortal/issues/new/choose) |
+
+Visite también el proyecto en [GitHub](https://github.com/haitiansintech/HaitiCityPortal).
+
+[↑ Volver arriba](#índice)
+
+---
+
+[← Índice de documentación](README.es.md) · [Glosario](GLOSSARY.es.md) · [Despliegue →](DEPLOYMENT.es.md)

--- a/docs/FOR_MUNICIPALITIES.fr.md
+++ b/docs/FOR_MUNICIPALITIES.fr.md
@@ -1,0 +1,263 @@
+<!--
+Langues : English (FOR_MUNICIPALITIES.md) | Français (ce fichier) | Kreyòl (FOR_MUNICIPALITIES.ht.md) | Español (FOR_MUNICIPALITIES.es.md)
+-->
+
+**Langues :** [English](FOR_MUNICIPALITIES.md) · **Français** · [Kreyòl Ayisyen](FOR_MUNICIPALITIES.ht.md) · [Español](FOR_MUNICIPALITIES.es.md)
+
+[← Index de la documentation](README.fr.md) · [README du projet](../README.md) · [Glossaire](GLOSSARY.fr.md)
+
+---
+
+# Pour les municipalités
+
+Guide non technique pour les maires, conseillers et agents municipaux qui envisagent Haiti City Portal pour leur commune.
+
+## Sommaire
+
+- [Qu'est-ce que Haiti City Portal ?](#quest-ce-que-haiti-city-portal-)
+- [Que peuvent faire vos résidents ?](#que-peuvent-faire-vos-résidents-)
+- [Que peut faire votre personnel ?](#que-peut-faire-votre-personnel-)
+- [Ce qu'il vous faut pour le faire tourner](#ce-quil-vous-faut-pour-le-faire-tourner)
+- [Coûts estimatifs](#coûts-estimatifs)
+- [Délai de mise en ligne](#délai-de-mise-en-ligne)
+- [Rôles requis chez vous](#rôles-requis-chez-vous)
+- [Langues et accessibilité](#langues-et-accessibilité)
+- [Données, propriété et confidentialité](#données-propriété-et-confidentialité)
+- [Questions fréquentes](#questions-fréquentes)
+- [Comment commencer](#comment-commencer)
+- [Qui contacter](#qui-contacter)
+
+---
+
+## Qu'est-ce que Haiti City Portal ?
+
+Haiti City Portal est un **logiciel libre et gratuit** pour les communes haïtiennes. Il offre à vos résidents un site web unique où ils peuvent :
+
+- Consulter les informations sur les services municipaux
+- Soumettre des demandes et signaler des problèmes (nids-de-poule, ordures, éclairage)
+- Payer les frais municipaux via MonCash ou virement bancaire
+- Lire les actualités officielles et les alertes d'urgence
+- Trouver hôpitaux, écoles, postes de police
+- Voir les élus et les contacter
+
+Il offre aussi à votre personnel un panneau d'administration pour gérer les demandes, vérifier les paiements, publier des actualités et diffuser des alertes.
+
+Il est conçu pour qu'**un même système partagé puisse desservir n'importe quel nombre de communes**. Chaque commune a son propre sous-domaine (par ex. `jacmel.portal.ht`, `cap.portal.ht`) et ses propres données — totalement séparées des autres communes.
+
+> **En une phrase :** c'est le même type de système qu'utilisent des villes comme Boston ou Lyon, mais conçu spécifiquement pour Haïti — multilingue par défaut, prêt pour les faibles débits, et adapté aux réalités locales (CASEC, ASEC, MonCash, NIF).
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Que peuvent faire vos résidents ?
+
+| Fonctionnalité | Pourquoi ça compte |
+|---|---|
+| Trouver un service et voir les documents requis | Réduit les déplacements inutiles à la mairie |
+| Signaler un problème avec photo et localisation GPS | Les problèmes ne tombent plus dans l'oubli |
+| Payer en ligne via MonCash ou virement | Moins de cash, moins de files |
+| Recevoir un reçu numérique (quittance) | Moins de papier, moins de fraude |
+| Voir tous les équipements publics sur une carte | Aide plus rapide en cas d'urgence |
+| Lire actualités et alertes officielles | Information autoritative remplace rumeur |
+| Utiliser le site en créole, français, anglais ou espagnol | Accès égal pour les résidents et la diaspora |
+| Voir les élus par section communale | Responsabilité démocratique renforcée |
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Que peut faire votre personnel ?
+
+| Fonctionnalité admin | Qui l'utilise |
+|---|---|
+| Voir les demandes entrantes et changer leur statut | Personnel d'accueil |
+| Vérifier les paiements en attente avec relevés banque/MonCash | Agent financier |
+| Publier articles d'actualité et alertes d'urgence | Agent de communication |
+| Gérer la liste des élus et leurs coordonnées | Cabinet du maire |
+| Tenir à jour l'annuaire des installations et leurs GPS | Responsable SIG / engagement civique |
+| Consulter les tableaux financiers et snapshots d'audit | Maire / trésorier |
+| Lire et acquitter les articles du manuel de gouvernance | Tous les admins |
+| Restreindre qui peut faire quoi (rôles user/admin/superadmin) | IT / cabinet |
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Ce qu'il vous faut pour le faire tourner
+
+Trois choses seulement :
+
+1. **Un nom de domaine** — par exemple `portal.ht` ou le vôtre (`jacmel-mairie.ht`). Environ 15–30 $ par an.
+2. **Un compte d'hébergement** — recommandé : [Vercel](https://vercel.com) (gratuit pour les petites communes, 20–40 $/mois pour les plus grandes).
+3. **Une base PostgreSQL gérée** — recommandé : [Neon](https://neon.tech) (gratuit pour les petites communes, 19 $/mois pour le palier payant).
+
+Vous n'avez **pas** besoin de serveur physique, de salle serveur ou de matériel spécial. Tout tourne dans le cloud.
+
+Avec ces trois éléments, un développeur expérimenté peut déployer le portail de votre commune **en moins d'une journée**.
+
+Voir le détail dans [Déploiement](DEPLOYMENT.fr.md) et [Intégration d'une commune](TENANT_ONBOARDING.fr.md).
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Coûts estimatifs
+
+Pour une commune de taille moyenne (50 000–200 000 habitants) :
+
+| Poste | Coût mensuel indicatif |
+|---|---|
+| Nom de domaine | ~2 $/mois (payé annuellement) |
+| Hébergement (Vercel) | 0–40 $ |
+| Base de données (Neon) | 0–19 $ |
+| Service e-mail (optionnel, ex. Resend) | 0–20 $ |
+| Tuiles cartographiques (gratuites par défaut avec MapLibre) | 0 $ |
+| **Total** | **~20–80 $ / mois** |
+
+Ces chiffres ne couvrent que l'infrastructure. Ils **n'incluent pas** les personnes : un développeur pour déployer, un éditeur pour traduire, un admin pour vérifier les paiements. La plupart des communes peuvent assurer ces rôles avec leur personnel actuel.
+
+Une deuxième, troisième ou centième commune peut rejoindre le même déploiement partagé à **un coût additionnel quasi nul**, grâce à l'architecture multi-tenant.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Délai de mise en ligne
+
+Calendrier réaliste pour une commune :
+
+| Étape | Durée | Qui |
+|---|---|---|
+| Acheter le domaine, créer les comptes hébergement | 1 jour | IT ou développeur |
+| Déployer l'application | Demi-journée | Développeur |
+| Configurer votre sous-domaine et créer le tenant | 1 heure | Développeur |
+| Saisir élus, sections communales, installations | 1–3 jours | Communication + état civil |
+| Traduire ou rédiger les descriptions de services | 1–2 semaines | Équipe communication |
+| Former le personnel au panneau admin | Demi-journée | Cabinet |
+| Lancement restreint | 1 jour | Communication |
+| Lancement public | 1 jour | Cabinet du maire |
+
+**Total : 2–4 semaines de la décision au lancement public**, sous réserve de disponibilité du personnel.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Rôles requis chez vous
+
+| Rôle | Temps requis | Compétences |
+|---|---|---|
+| **Sponsor** (maire ou chef de cabinet) | Quelques heures au total | Pouvoir décisionnel, priorisation |
+| **Développeur / responsable IT** | 2–5 jours pour la mise en place, puis ponctuel | À l'aise avec Node.js, hébergement web, DNS. Interne, bénévole ou prestataire. |
+| **Agent de communication** | Continu | Rédige actualités, traduit services, publie alertes. Sans code. |
+| **Agent financier** | Continu | Vérifie les paiements |
+| **Personnel d'accueil** | Continu | Lit les demandes entrantes et change leurs statuts |
+
+Vous n'avez pas besoin d'une grande équipe. Un agent à l'aise avec le numérique plus l'équipe communication suffit pour la plupart des communes.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Langues et accessibilité
+
+Le portail est livré en quatre langues :
+
+- **Créole haïtien (Kreyòl Ayisyen)** — par défaut, langue maternelle de la grande majorité des Haïtiens.
+- **Français** — langue écrite officielle du gouvernement.
+- **Anglais** — pour la diaspora, les ONG et les partenaires.
+- **Espagnol** — accessibilité transfrontalière (République dominicaine, partenaires régionaux).
+
+Les résidents changent de langue en haut de chaque page. Si un contenu n'est pas encore traduit, le portail affiche automatiquement la version anglaise — pas de page cassée.
+
+Le site est conçu mobile-first, optimisé pour les faibles débits (2G/3G), et respecte les standards d'accessibilité web courants.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Données, propriété et confidentialité
+
+- **Vos données vous appartiennent.** Les résidents, demandes, paiements, actualités et élus de votre commune sont stockés dans *votre* base. Les autres communes du déploiement partagé ne peuvent pas voir vos données.
+- **Le logiciel est open source** sous la Business Source License 1.1. Toute commune peut l'utiliser librement à des fins non commerciales. Il devient Apache 2.0 (totalement libre) le 31 décembre 2028. Voir [LICENSE.md](../LICENSE.md).
+- **L'isolation entre tenants est appliquée au niveau du code.** Chaque requête filtre par `tenant_id`. Une fuite de données entre communes est traitée comme un incident de sécurité critique.
+- **Les mots de passe sont hachés.** Même les mainteneurs ne peuvent pas les lire.
+- **Aucun pistage analytique par défaut.** Vous décidez ce que vous ajoutez.
+
+Détails dans [Politique de sécurité](../SECURITY.md).
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Questions fréquentes
+
+**Q. Faut-il payer le logiciel ?**
+R. Non. Le code est gratuit. Vous payez uniquement l'infrastructure (domaine, hébergement, base) et votre personnel.
+
+**Q. Nous n'avons pas de développeur. Que faire ?**
+R. Trois options : (1) Demander à une université locale — beaucoup d'étudiants en informatique sauteraient sur ce projet. (2) Solliciter le réseau Haitians in Tech pour un bénévole ou prestataire abordable. (3) Écrire à `info@haiticity.org`, nous aiderons à mettre en relation.
+
+**Q. Peut-on personnaliser le site pour notre commune ?**
+R. Oui — nom, logo, couleurs, photos officielles, sections communales, services et actualités sont tous configurables par commune. La base graphique est partagée pour que toutes les communes apparaissent comme une infrastructure civique nationale cohérente.
+
+**Q. Peut-on ajouter un service propre à notre commune ?**
+R. Oui. Les services se définissent dans des fichiers de contenu modifiables par n'importe qui. Voir [Guide de contenu](CONTENT_GUIDE.fr.md).
+
+**Q. Et si notre Internet est instable ?**
+R. Le site est optimisé pour faibles débits. La soumission hors-ligne est sur la feuille de route ([État de l'implémentation](v0.1-implementation-plan.md)).
+
+**Q. Si MonCash est en panne ?**
+R. Le virement bancaire sert de solution de repli. Le système émet un code mémo que les résidents joignent à leur paiement, et un admin vérifie manuellement. L'intégration MonCash en webhook est sur la feuille de route.
+
+**Q. Nous avons déjà un site. Pourquoi changer ?**
+R. Vous n'êtes pas obligé. Vous pouvez faire tourner le portail sur un sous-domaine (`services.votre-mairie.ht`) et le relier à votre site existant. Ou en faire votre site principal. Au choix.
+
+**Q. Les résidents peuvent-ils créer un compte ?**
+R. Aujourd'hui, ils peuvent soumettre des demandes anonymement. La création de compte (suivi de demandes) est sur la feuille de route.
+
+**Q. Et la diaspora ?**
+R. Le portail est multilingue (anglais/français/espagnol) et accepte les virements internationaux pour les projets communautaires. Stripe (USD/EUR) est sur la feuille de route.
+
+**Q. Peut-on intégrer nos systèmes existants (ex. fiscalité) ?**
+R. Oui. Le portail expose des API et peut être étendu. Parlez-en à votre développeur.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Comment commencer
+
+1. Lire ce document et le [Glossaire](GLOSSARY.fr.md) — partager les deux avec les décideurs.
+2. Identifier votre développeur / IT et lui partager [Déploiement](DEPLOYMENT.fr.md) et [Intégration d'une commune](TENANT_ONBOARDING.fr.md).
+3. Identifier votre référent contenu (communication) et lui partager [Guide de contenu](CONTENT_GUIDE.fr.md).
+4. Choisir un domaine (ou sous-domaine).
+5. Créer les comptes hébergement et base.
+6. Déployer.
+7. Intégrer votre commune (la créer dans le système).
+8. Saisir élus, sections, installations, services, actualités.
+9. Former le personnel avec [Manuel d'administration](ADMIN_MANUAL.fr.md).
+10. Lancer.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Qui contacter
+
+| Motif | Contact |
+|---|---|
+| Questions générales | `info@haiticity.org` |
+| Trouver un développeur | `info@haiticity.org` |
+| Sécurité ou vulnérabilité | `security@haiticity.org` |
+| Licence pour usage commercial | `licensing@haiticity.org` |
+| Bug ou demande de fonctionnalité | [Ouvrir une issue](https://github.com/haitiansintech/HaitiCityPortal/issues/new/choose) |
+
+Voir aussi le projet sur [GitHub](https://github.com/haitiansintech/HaitiCityPortal).
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+[← Index de la documentation](README.fr.md) · [Glossaire](GLOSSARY.fr.md) · [Déploiement →](DEPLOYMENT.fr.md)

--- a/docs/FOR_MUNICIPALITIES.ht.md
+++ b/docs/FOR_MUNICIPALITIES.ht.md
@@ -1,0 +1,263 @@
+<!--
+Lang yo: English (FOR_MUNICIPALITIES.md) | Français (FOR_MUNICIPALITIES.fr.md) | Kreyòl (fichye sa a) | Español (FOR_MUNICIPALITIES.es.md)
+-->
+
+**Lang yo:** [English](FOR_MUNICIPALITIES.md) · [Français](FOR_MUNICIPALITIES.fr.md) · **Kreyòl Ayisyen** · [Español](FOR_MUNICIPALITIES.es.md)
+
+[← Endèks dokimantasyon](README.ht.md) · [README pwojè a](../README.md) · [Glosè](GLOSSARY.ht.md)
+
+---
+
+# Pou Minisipalite yo
+
+Yon gid ki pa teknik pou majistra, konseye, ak anplwaye lameri k ap konsidere Haiti City Portal pou komin yo.
+
+## Tablo Kontni
+
+- [Kisa Haiti City Portal ye?](#kisa-haiti-city-portal-ye)
+- [Ki sa rezidan ou yo ka fè?](#ki-sa-rezidan-ou-yo-ka-fè)
+- [Ki sa staf ou ka fè?](#ki-sa-staf-ou-ka-fè)
+- [Sa w bezwen pou fè l mache](#sa-w-bezwen-pou-fè-l-mache)
+- [Estimasyon pri](#estimasyon-pri)
+- [Tan pou lansman](#tan-pou-lansman)
+- [Wòl ou bezwen sou bò pa w](#wòl-ou-bezwen-sou-bò-pa-w)
+- [Lang ak aksesibilite](#lang-ak-aksesibilite)
+- [Done, pwopriyete, ak vi prive](#done-pwopriyete-ak-vi-prive)
+- [Kesyon yo poze souvan](#kesyon-yo-poze-souvan)
+- [Kijan pou kòmanse](#kijan-pou-kòmanse)
+- [Ak kilès pou kontakte](#ak-kilès-pou-kontakte)
+
+---
+
+## Kisa Haiti City Portal ye?
+
+Haiti City Portal se yon **lojisyèl gratis ak kòd louvri** pou komin ayisyen yo. Li bay rezidan ou yo yon sèl sit entènèt kote yo ka:
+
+- Wè enfòmasyon sou sèvis lameri yo
+- Soumèt demann epi siyale pwoblèm (twou nan wout, fatra, limyè)
+- Peye frè lameri pa MonCash oswa transfè bankè
+- Li nouvèl ofisyèl ak alèt ijans
+- Jwenn lopital, lekòl, ak komisarya
+- Wè ofisyèl eli yo epi kontakte yo
+
+Li bay tou staf ou yon panèl administrasyon pou jere demann, verifye peyman, pibliye nouvèl, ak voye alèt ijans.
+
+Li fèt pou **yon menm sistèm pataje ka sèvi nenpòt kantite komin**. Chak komin gen pwòp soudomèn li (egzanp `jacmel.portal.ht`, `cap.portal.ht`) ak pwòp done li — totalman separe ak lòt komin yo.
+
+> **Nan yon fraz:** se menm kalite sistèm yon vil tankou Boston oswa Lyon itilize, men fèt espesyalman pou Ayiti — milti-lang pa default, pare pou ti bandlarjè, epi adapte ak reyalite lokal yo (CASEC, ASEC, MonCash, NIF).
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Ki sa rezidan ou yo ka fè?
+
+| Sa rezidan ka fè | Poukisa li enpòtan |
+|---|---|
+| Jwenn yon sèvis epi wè dokiman ki nesesè | Mwens vwayaj initil nan lameri |
+| Siyale yon pwoblèm ak foto ak GPS | Pwoblèm yo pa pèdi nan vid |
+| Peye anliy pa MonCash oswa transfè | Mwens kach, mwens lafil |
+| Resevwa yon kitans dijital | Mwens papye, mwens fwod |
+| Wè tout etablisman piblik sou yon kat | Èd pi rapid nan ka ijans |
+| Li nouvèl ak alèt ofisyèl | Enfòmasyon serye ranplase rimè |
+| Itilize sit la an kreyòl, franse, anglè oswa espanyòl | Aksè egal pou rezidan ak dyaspora |
+| Wè ofisyèl pa seksyon kominal | Plis responsablite demokratik |
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Ki sa staf ou ka fè?
+
+| Sa admin ka fè | Kilès ki itilize l |
+|---|---|
+| Wè demann k ap antre epi chanje estati yo | Anplwaye akèy |
+| Verifye peyman annatant ak relve labank/MonCash | Ofisye finans |
+| Pibliye atik nouvèl ak alèt ijans | Ofisye kominikasyon |
+| Jere lis ofisyèl yo ak kowòdone yo | Kabinè majistra |
+| Mete ajou ane riye etablisman ak GPS yo | Responsab SIG / angajman sivik |
+| Wè tablobò finans ak snapshot odit | Majistra / trezorye |
+| Li ak akeyi atik manyèl gouvènans | Tout admin |
+| Restren kilès ka fè kisa (wòl user/admin/superadmin) | IT / kabinè |
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Sa w bezwen pou fè l mache
+
+Sèlman twa bagay:
+
+1. **Yon non domèn** — egzanp `portal.ht` oswa pa w (`jacmel-mairie.ht`). Anviwon $15–30 pa ane.
+2. **Yon kont ebèjman** — rekòmande: [Vercel](https://vercel.com) (gratis pou ti komin, $20–40/mwa pou pi gwo).
+3. **Yon baz PostgreSQL jere** — rekòmande: [Neon](https://neon.tech) (gratis pou ti komin, $19/mwa nivo peye).
+
+Ou **pa bezwen** sèvè fizik, sal sèvè, oswa materyèl espesyal. Tout bagay nan nyaj la.
+
+Avèk sa twa yo, yon devlopè eksperyans ka deplwaye pòtal komin ou **nan mwens pase yon jou**.
+
+Wè detay nan [Deplwaman](DEPLOYMENT.ht.md) ak [Mete yon Vil Anplas](TENANT_ONBOARDING.ht.md).
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Estimasyon pri
+
+Pou yon komin gwosè mwayèn (50 000–200 000 abitan):
+
+| Atik | Pri mwayè/mwa |
+|---|---|
+| Non domèn | ~$2/mwa (peye chak ane) |
+| Ebèjman (Vercel) | $0–40 |
+| Baz done (Neon) | $0–19 |
+| Sèvis imèl (opsyonèl, egz. Resend) | $0–20 |
+| Karo kat (gratis pa default ak MapLibre) | $0 |
+| **Total** | **~$20–80 / mwa** |
+
+Chif sa yo se pou enfrastrikti sèlman. Yo **pa kouvri** moun: yon devlopè pou deplwaye, yon editè pou tradwi, yon admin pou verifye peyman. Plizyè komin ka kouvri wòl sa yo ak staf yo gen deja.
+
+Yon dezyèm, twazyèm, oswa santyèm komin ka rantre nan menm deplwaman pataje a ak yon **pri adisyonèl prèske zewo**, gras ak achitekti milti-tenant la.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Tan pou lansman
+
+Kalandriye reyalis pou yon komin:
+
+| Etap | Tan | Kilès |
+|---|---|---|
+| Achte domèn, mete kont ebèjman ak baz done | 1 jou | IT oswa devlopè |
+| Deplwaye aplikasyon an | Mwatye jou | Devlopè |
+| Konfigire soudomèn ou epi kreye tenant la | 1 èdtan | Devlopè |
+| Antre ofisyèl, seksyon kominal, etablisman | 1–3 jou | Kominikasyon + eta sivil |
+| Tradwi oswa ekri deskripsyon sèvis | 1–2 semèn | Ekip kominikasyon |
+| Fòme staf sou panèl admin | Mwatye jou | Kabinè |
+| Lansman restren | 1 jou | Kominikasyon |
+| Lansman piblik | 1 jou | Kabinè majistra |
+
+**Total: 2–4 semèn ant desizyon ak lansman piblik**, dapre disponibilite staf.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Wòl ou bezwen sou bò pa w
+
+| Wòl | Tan ki bezwen | Konpetans |
+|---|---|---|
+| **Sponsò** (majistra oswa chèf kabinè) | Kèk èdtan an total | Pouvwa desizyon, priyorize |
+| **Devlopè / lidè IT** | 2–5 jou pou enstalasyon, apre sa pa souvan | Alèz ak Node.js, ebèjman, DNS. Anndan, volontè, oswa kontraktè. |
+| **Ofisye kominikasyon** | Kontinyèl | Ekri nouvèl, tradwi sèvis, mete alèt. San kòd. |
+| **Ofisye finans** | Kontinyèl | Verifye peyman ak relve banke/MonCash |
+| **Anplwaye akèy** | Kontinyèl | Li demann k ap antre epi chanje estati yo |
+
+Ou pa bezwen yon gwo ekip. Yon sèl moun nan staf ki alèz ak nimerik plis ekip kominikasyon majistra ase pou pifò komin.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Lang ak aksesibilite
+
+Pòtal la livre nan kat lang:
+
+- **Kreyòl Ayisyen** — pa default, paske se lang manman pou pifò ayisyen.
+- **Franse** — lang ekri ofisyèl gouvènman an.
+- **Anglè** — pou dyaspora, ONG, ak patnè.
+- **Espanyòl** — aksesibilite tranfwontye (Repiblik Dominikèn, patnè rejyonal).
+
+Rezidan yo chanje lang an wo chak paj. Si yon kontni poko tradwi, pòtal la otomatikman montre vèsyon anglè a — pa gen paj kase.
+
+Sit la fèt mobil-an-premye, optimize pou ti bandlarjè (2G/3G), epi respekte estanda aksesibilite web kouran yo.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Done, pwopriyete, ak vi prive
+
+- **Done w yo se pou ou.** Rezidan, demann, peyman, nouvèl, ak ofisyèl komin ou estoke nan baz *pa w*. Lòt komin sou menm deplwaman pataje pa ka wè done w.
+- **Lojisyèl la kòd louvri** anba Business Source License 1.1. Nenpòt komin ka itilize l librman pou itilizasyon ki pa komèsyal. Li vin Apache 2.0 (konplètman lib) nan 31 desanm 2028. Wè [LICENSE.md](../LICENSE.md).
+- **Izolasyon ant tenant aplike nan nivo kòd la.** Chak rekèt baz done filtre pa `tenant_id`. Yon bug ki pèmèt done yon komin parèt nan yon lòt trete kòm yon ensidan sekirite kritik.
+- **Modpas yo hash.** Menm mainteneur pwojè a pa ka li yo.
+- **Pa gen swiv analitik pa default.** Ou deside sa w ajoute.
+
+Detay nan [Politik Sekirite](../SECURITY.md).
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Kesyon yo poze souvan
+
+**K. Èske nou dwe peye pou itilize lojisyèl sa a?**
+R. Non. Kòd la gratis. Ou peye sèlman enfrastrikti (domèn, ebèjman, baz) ak tan staf ou.
+
+**K. Nou pa gen devlopè. Sa pou n fè?**
+R. Twa opsyon: (1) Mande yon inivèsite lokal — anpil etidyan enfòmatik ta sote sou yon pwojè konsa pou kredi oswa tèz. (2) Kontakte rezo Haitians in Tech la pou yon volontè oswa kontraktè bon pri. (3) Ekri nan `info@haiticity.org`, n ap ede konekte w.
+
+**K. Èske nou ka pèsonalize sit la pou komin nou?**
+R. Wi — non, lòlò, koulè, foto ofisyèl, seksyon kominal, sèvis, ak nouvèl tout konfigirab pa komin. Baz grafik la pataje pou tout komin parèt kòm yon enfrastrikti sivik nasyonal.
+
+**K. Èske nou ka ajoute yon sèvis espesifik pou komin nou?**
+R. Wi. Sèvis defini nan fichye kontni nenpòt moun ka modifye. Wè [Gid Kontni](CONTENT_GUIDE.ht.md).
+
+**K. E si entènèt nou pa fyab?**
+R. Sit la optimize pou ti bandlarjè. Soumisyon ofliy sou plan ([Estati Aplikasyon](v0.1-implementation-plan.md)).
+
+**K. E si MonCash anpàn?**
+R. Transfè bankè se yon altènatif. Sistèm lan bay yon kòd memo rezidan mete ak peyman l, epi yon admin verifye manyèlman. Entegrasyon MonCash dirèk sou plan.
+
+**K. Nou gen yon sit deja. Poukisa chanje?**
+R. Ou pa oblije. Ou ka fè pòtal la mache nan yon soudomèn (`services.lameri-w.ht`) epi konekte l ak sit ou genyen an. Oswa fè l sit prensipal ou. Chwa pa w.
+
+**K. Èske rezidan ka kreye kont?**
+R. Jodi a, yo ka soumèt demann anonim. Kreyasyon kont pou rezidan (suiv demann) sou plan.
+
+**K. E dyaspora a?**
+R. Pòtal la milti-lang (anglè/franse/espanyòl) epi sipòte transfè entènasyonal pou pwojè kominote. Stripe (USD/EUR) sou plan.
+
+**K. Èske n ka entegre ak sistèm nou genyen (egz. dosye taks)?**
+R. Wi. Pòtal la ekspoze API epi ka pwolonje. Pale ak devlopè w.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Kijan pou kòmanse
+
+1. Li dokiman sa a ak [Glosè](GLOSSARY.ht.md) — pataje toulède ak desidè yo.
+2. Idantifye devlopè / lidè IT epi pataje [Deplwaman](DEPLOYMENT.ht.md) ak [Mete yon Vil Anplas](TENANT_ONBOARDING.ht.md) avèk li.
+3. Idantifye lidè kontni ou (kominikasyon) epi pataje [Gid Kontni](CONTENT_GUIDE.ht.md) avèk li.
+4. Deside yon domèn (oswa soudomèn).
+5. Mete kont ebèjman ak baz done.
+6. Deplwaye.
+7. Mete tenant ou (kreye komin ou nan sistèm lan).
+8. Antre ofisyèl, seksyon, etablisman, sèvis, nouvèl.
+9. Fòme staf ak [Manyèl Administrasyon](ADMIN_MANUAL.ht.md).
+10. Lanse.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Ak kilès pou kontakte
+
+| Rezon | Kontak |
+|---|---|
+| Kesyon jeneral | `info@haiticity.org` |
+| Èd jwenn yon devlopè | `info@haiticity.org` |
+| Sekirite oswa vilnerabilite | `security@haiticity.org` |
+| Lisans pou itilizasyon komèsyal | `licensing@haiticity.org` |
+| Bug oswa demann fonksyonalite | [Louvri yon issue](https://github.com/haitiansintech/HaitiCityPortal/issues/new/choose) |
+
+Wè pwojè a sou [GitHub](https://github.com/haitiansintech/HaitiCityPortal).
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+[← Endèks dokimantasyon](README.ht.md) · [Glosè](GLOSSARY.ht.md) · [Deplwaman →](DEPLOYMENT.ht.md)

--- a/docs/FOR_MUNICIPALITIES.md
+++ b/docs/FOR_MUNICIPALITIES.md
@@ -1,0 +1,263 @@
+<!--
+Languages: English (this file) | Français (FOR_MUNICIPALITIES.fr.md) | Kreyòl (FOR_MUNICIPALITIES.ht.md) | Español (FOR_MUNICIPALITIES.es.md)
+-->
+
+**Languages:** **English** · [Français](FOR_MUNICIPALITIES.fr.md) · [Kreyòl Ayisyen](FOR_MUNICIPALITIES.ht.md) · [Español](FOR_MUNICIPALITIES.es.md)
+
+[← Docs index](README.md) · [Project README](../README.md) · [Glossary](GLOSSARY.md)
+
+---
+
+# For Municipalities
+
+A non-technical guide for mayors, councillors, and city staff considering Haiti City Portal for their commune.
+
+## Table of Contents
+
+- [What is Haiti City Portal?](#what-is-haiti-city-portal)
+- [What can your residents do with it?](#what-can-your-residents-do-with-it)
+- [What can your staff do with it?](#what-can-your-staff-do-with-it)
+- [What you need to run it](#what-you-need-to-run-it)
+- [Estimated costs](#estimated-costs)
+- [Time to launch](#time-to-launch)
+- [Roles required on your side](#roles-required-on-your-side)
+- [Languages and accessibility](#languages-and-accessibility)
+- [Data, ownership, and privacy](#data-ownership-and-privacy)
+- [Frequently asked questions](#frequently-asked-questions)
+- [How to get started](#how-to-get-started)
+- [Who to contact](#who-to-contact)
+
+---
+
+## What is Haiti City Portal?
+
+Haiti City Portal is **free, open-source software** for Haitian communes. It gives your residents a single website where they can:
+
+- See information about city services
+- Submit requests and report problems (potholes, garbage, lighting)
+- Pay city fees through MonCash or bank transfer
+- Read official news and emergency alerts
+- Find hospitals, schools, and police stations
+- View elected officials and contact them
+
+It also gives your staff an admin panel to manage requests, verify payments, publish news, and post emergency alerts.
+
+It is built so that **one shared system can serve any number of communes**. Each commune has its own subdomain (e.g. `jacmel.portal.ht`, `cap.portal.ht`) and its own data — completely separated from every other commune.
+
+> **In one sentence:** It is the same kind of system a city like Boston or Lyon uses, but designed specifically for Haiti — multilingual by default, low-bandwidth ready, and adapted to local realities like CASEC, ASEC, MonCash, and NIF.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## What can your residents do with it?
+
+| Citizen feature | Why it matters |
+|---|---|
+| Find a service and see what documents are required | Reduces wasted trips to city hall |
+| Report a problem with photo and GPS location | Issues stop falling through the cracks |
+| Pay fees online via MonCash or wire transfer | Less cash handling, less queueing |
+| Get a digital receipt (quittance) | Reduces paper, reduces fraud |
+| See the location of every public facility on a map | Faster help in emergencies |
+| Read official news and emergency alerts | Authoritative information replaces rumour |
+| Use the site in Creole, French, English, or Spanish | Equal access for residents and the diaspora |
+| See elected officials by communal section | Stronger democratic accountability |
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## What can your staff do with it?
+
+| Admin feature | Who uses it |
+|---|---|
+| See incoming service requests and update their status | Service desk staff |
+| Verify pending payments against bank/MonCash statements | Finance officer |
+| Publish news articles and emergency alerts | Communications officer |
+| Manage the list of officials and their contact info | Mayor's chief of staff |
+| Maintain the directory of facilities and their GPS coordinates | GIS lead / civic engagement officer |
+| View finance dashboards and audit snapshots | Mayor / treasurer |
+| Read and acknowledge governance handbook articles | All admins |
+| Restrict who can do what (user / admin / superadmin roles) | IT / chief of staff |
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## What you need to run it
+
+Three things only:
+
+1. **A domain name** — for example `portal.ht`, or your own (`jacmel-mairie.ht`). About $15–$30 per year.
+2. **A hosting account** — recommended: [Vercel](https://vercel.com) (free for small communes, $20–40/month for larger). The hosting runs the website itself.
+3. **A managed PostgreSQL database** — recommended: [Neon](https://neon.tech) (free for small communes, $19/month for the standard paid tier). The database stores your residents' submissions, payments, news, etc.
+
+You do **not** need a physical server, a server room, or special hardware. Everything runs in the cloud.
+
+If you have access to all three, an experienced developer can deploy your commune's portal in **under a day**.
+
+See the full step-by-step in [Deployment](DEPLOYMENT.md) and [Tenant Onboarding](TENANT_ONBOARDING.md).
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Estimated costs
+
+For a single commune of typical size (say, 50,000–200,000 residents):
+
+| Item | Indicative monthly cost |
+|---|---|
+| Domain name | ~$2/month (paid yearly) |
+| Hosting (Vercel) | $0–$40 |
+| Database (Neon) | $0–$19 |
+| Email service for notifications (optional, e.g. Resend) | $0–$20 |
+| Map tile provider (free with MapLibre defaults) | $0 |
+| **Total** | **~$20–$80 / month** |
+
+These are pure infrastructure costs. They **do not include** people: a developer to deploy, a content editor to translate, an admin to verify payments. Many communes can fill these roles with existing staff.
+
+A second, third, or hundredth commune can join the same shared deployment at **near-zero added cost**, because the multi-tenant architecture serves them all from one running system.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Time to launch
+
+A realistic timeline for a single commune:
+
+| Stage | Time | Who |
+|---|---|---|
+| Buy domain, set up hosting accounts | 1 day | IT staff or a developer |
+| Deploy the application | Half a day | Developer |
+| Configure your subdomain and create the tenant record | 1 hour | Developer |
+| Add your officials, communal sections, facilities | 1–3 days | Communications + records office |
+| Translate or write your service descriptions | 1–2 weeks | Communications team |
+| Train staff on the admin panel | Half a day | Chief of staff |
+| Soft launch (announce to a small group) | 1 day | Communications |
+| Public launch (announce to all residents) | 1 day | Mayor's office |
+
+**Total: 2–4 weeks from decision to public launch**, assuming staff availability.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Roles required on your side
+
+| Role | Time needed | Skills |
+|---|---|---|
+| **Sponsor** (mayor or chief of staff) | A few hours total | Decision authority, prioritisation |
+| **Developer / IT lead** | 2–5 days for setup, then occasional | Comfortable with Node.js, web hosting, DNS. Can be in-house, a volunteer, or contracted. |
+| **Communications officer** | Ongoing | Writes news, translates services, posts alerts. No coding. |
+| **Finance officer** | Ongoing | Verifies payments against bank/MonCash statements |
+| **Service desk staff** | Ongoing | Reads incoming requests and updates their status |
+
+You don't need a large team. A single tech-savvy staff member plus the mayor's communications team is enough for most communes.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Languages and accessibility
+
+The portal ships in four languages:
+
+- **Haitian Creole (Kreyòl Ayisyen)** — the default, because it is the mother tongue of the great majority of Haitians.
+- **French** — the official written language of government.
+- **English** — for the diaspora, NGOs, and partner organisations.
+- **Spanish** — for cross-border accessibility (Dominican Republic, regional partners).
+
+Residents can switch languages at the top of every page. If a piece of content has not yet been translated to Creole or Spanish, the portal automatically shows the English version — no broken pages.
+
+The site is built mobile-first, optimised for low-bandwidth (2G/3G) connections, and meets common web accessibility standards.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Data, ownership, and privacy
+
+- **You own your data.** Your commune's residents, requests, payments, news, and officials are stored in *your* database. Other communes on the same shared deployment cannot see your data.
+- **The software is open source** under the Business Source License 1.1. Any commune can use it freely for non-commercial purposes. It converts to Apache 2.0 (fully open) on December 31, 2028. See [LICENSE.md](../LICENSE.md).
+- **Cross-tenant isolation is enforced at the code level.** Every database query is scoped by `tenant_id` (your commune's unique identifier). A bug that allows one commune's data to leak into another is treated as a critical security incident.
+- **Passwords are hashed.** Even the project maintainers cannot read them.
+- **No analytics tracking by default.** You decide what you add.
+
+For full details see [Security Policy](../SECURITY.md).
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Frequently asked questions
+
+**Q. Do we have to pay anything to use this software?**
+A. No. The code is free. You only pay for the infrastructure that runs it (domain, hosting, database) and your own staff time.
+
+**Q. We don't have a developer. What do we do?**
+A. Three options: (1) Ask a local university — many computer science students would jump at this kind of project for credit or a thesis. (2) Reach out to the Haitians in Tech network for a volunteer or low-cost contractor. (3) Email `info@haiticity.org` and we will help connect you.
+
+**Q. Can we customise the site for our commune?**
+A. Yes — your name, logo, colours, official photos, communal sections, services, and news are all configurable per commune. The base design is shared so all communes feel like part of one national civic infrastructure.
+
+**Q. Can we add a service that's specific to our commune?**
+A. Yes. Services are defined in content files anyone can edit. See [Content Guide](CONTENT_GUIDE.md).
+
+**Q. What if our internet is unreliable?**
+A. The site is optimised for low bandwidth. Offline form submission is on the roadmap (see [Implementation Status](v0.1-implementation-plan.md)).
+
+**Q. What if MonCash is down?**
+A. Wire transfer is supported as a fallback. The system issues a memo code that residents include with their payment, and an admin verifies receipt manually. Live MonCash webhook integration is on the roadmap.
+
+**Q. We already have a website. Why switch?**
+A. You don't have to. You can run the portal at a subdomain (like `services.your-mairie.ht`) and link to it from your existing site. Or use the portal as your main site. Your choice.
+
+**Q. Can residents create accounts?**
+A. Today, residents can submit requests anonymously. Account creation for residents (to track their own requests) is on the roadmap.
+
+**Q. What about the diaspora?**
+A. The portal is multilingual (English/French/Spanish) and supports international wire transfers for fundraising and community projects. Stripe support for diaspora-friendly USD/EUR payments is on the roadmap.
+
+**Q. Can we integrate with our existing systems (e.g. tax records)?**
+A. Yes. The portal exposes API endpoints and can be extended with custom integrations. Talk to your developer.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## How to get started
+
+1. Read this document and the [Glossary](GLOSSARY.md) — share both with your decision-makers.
+2. Identify your developer or IT lead and share [Deployment](DEPLOYMENT.md) and [Tenant Onboarding](TENANT_ONBOARDING.md) with them.
+3. Identify your content lead (communications officer) and share [Content Guide](CONTENT_GUIDE.md).
+4. Decide on a domain (or subdomain).
+5. Set up the hosting and database accounts.
+6. Deploy.
+7. Onboard your tenant (add your commune to the system).
+8. Add officials, sections, facilities, services, news.
+9. Train staff with [Admin Manual](ADMIN_MANUAL.md).
+10. Launch.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Who to contact
+
+| Reason | Contact |
+|---|---|
+| General questions about the project | `info@haiticity.org` |
+| Help finding a developer | `info@haiticity.org` |
+| Security concern or vulnerability | `security@haiticity.org` |
+| Licensing for commercial use | `licensing@haiticity.org` |
+| Bug report or feature request | [Open an issue on GitHub](https://github.com/haitiansintech/HaitiCityPortal/issues/new/choose) |
+
+You can also visit the project on [GitHub](https://github.com/haitiansintech/HaitiCityPortal) to see all activity, read the code, and contribute.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+[← Docs index](README.md) · [Glossary](GLOSSARY.md) · [Deployment →](DEPLOYMENT.md)

--- a/docs/GLOSSARY.es.md
+++ b/docs/GLOSSARY.es.md
@@ -1,0 +1,158 @@
+<!--
+Idiomas: English (GLOSSARY.md) | Français (GLOSSARY.fr.md) | Kreyòl (GLOSSARY.ht.md) | Español (este archivo)
+-->
+
+**Idiomas:** [English](GLOSSARY.md) · [Français](GLOSSARY.fr.md) · [Kreyòl Ayisyen](GLOSSARY.ht.md) · **Español**
+
+[← Índice de documentación](README.es.md) · [README del proyecto](../README.md)
+
+---
+
+# Glosario
+
+Definiciones en lenguaje claro de cada término técnico, cívico y específico de Haití usado en esta documentación. Si una palabra le bloquea, búsquela aquí. Si falta un término, [abra una Pull Request](https://github.com/haitiansintech/HaitiCityPortal/edit/main/docs/GLOSSARY.es.md) o [un issue](https://github.com/haitiansintech/HaitiCityPortal/issues/new/choose).
+
+## Índice
+
+- [Términos cívicos y haitianos](#términos-cívicos-y-haitianos)
+- [Términos técnicos](#términos-técnicos)
+- [Términos de operación](#términos-de-operación)
+- [Términos específicos del proyecto](#términos-específicos-del-proyecto)
+- [Siglas](#siglas)
+
+---
+
+## Términos cívicos y haitianos
+
+| Término | Significado |
+|---|---|
+| **CASEC** | *Conseil d'Administration de la Section Communale*. Consejo electo de tres personas que gobierna una *sección comunal*. |
+| **ASEC** | *Assemblée de la Section Communale*. Asamblea legislativa electa de una sección comunal, junto al CASEC. |
+| **Comuna** | Municipalidad en Haití — equivalente a una ciudad o pueblo. Cada comuna tiene un alcalde; es el nivel al que sirve este portal. |
+| **Sección comunal** | Subunidad geográfica de una comuna, gobernada por un CASEC + ASEC. |
+| **Alcalde** | Cabeza electa de una comuna. |
+| **Delegado de Ciudad** | Representante del gobierno central nombrado en una comuna. |
+| **MonCash** | Servicio de dinero móvil más usado en Haití, operado por Digicel. Muchos residentes pagan facturas con MonCash. |
+| **NIF** | *Numéro d'Identification Fiscale*. Identificación fiscal haitiana — requerida para la mayoría de trámites oficiales. |
+| **CIN** | *Carte d'Identification Nationale*. La cédula de identidad nacional haitiana. |
+| **Quittance** (fr/kreyòl) | Recibo o comprobante de pago. El portal emite una *quittance* cuando un pago se verifica. |
+| **Open311** | Estándar internacional abierto para que ciudadanos reporten problemas no urgentes (baches, basura, alumbrado) a una municipalidad. El formulario `/report` del portal sigue este estándar. |
+
+---
+
+## Términos técnicos
+
+| Término | Significado |
+|---|---|
+| **Frontend** | Parte de una aplicación que corre en el navegador del usuario (páginas, formularios, botones). |
+| **Backend** | Parte que corre en un servidor: login, base de datos, pagos. El usuario nunca ve el código backend. |
+| **Full-stack** | Aplicación que contiene tanto frontend como backend en el mismo proyecto. Haiti City Portal es full-stack. |
+| **Next.js** | El framework web sobre el que está construido el proyecto. Produce páginas (frontend) y lógica de servidor (backend) desde un único código. |
+| **App Router** | El sistema de rutas moderno de Next.js 13+ donde cada carpeta bajo `src/app/` se convierte en una URL. |
+| **React** | La biblioteca JavaScript que usa Next.js para construir interfaces. |
+| **Server Component** | Página o componente que corre en el servidor y envía HTML ya listo al navegador. Más rápido, mejor para SEO, puede leer la base de datos directamente. |
+| **Client Component** | Componente que corre en el navegador. Necesario para cosas interactivas (mapas, formularios, animaciones). Marcado con `"use client"` arriba del archivo. |
+| **Server Action** | Función backend invocable directamente desde un formulario. Definida en `src/app/actions/`. |
+| **API route** | Endpoint backend en una URL como `/api/health`. |
+| **Middleware** | Código que corre en el servidor *antes* de renderizar la página. Este proyecto lo usa para detectar idioma, identificar la ciudad (tenant) y proteger páginas admin. |
+| **Base de datos** | Donde se almacenan datos dinámicos: ciudades, usuarios, solicitudes, pagos, eventos. |
+| **PostgreSQL (Postgres)** | El motor de base de datos usado. Gratuito, open source, muy usado. |
+| **Drizzle ORM** | Herramienta que permite escribir consultas en TypeScript en vez de SQL puro. Esquema en `src/db/schema.ts`. |
+| **Esquema** | Plano de la base: qué tablas existen, qué columnas, qué tipos. |
+| **Migración** | Archivo que actualiza el esquema (agrega columna, renombra tabla). Drizzle los genera. |
+| **Seeding** | Insertar datos iniciales en una base vacía (ej. una ciudad demo). Se corre con `npm run db:seed`. |
+| **TypeScript** | Versión de JavaScript con verificación de tipos — atrapa muchos errores antes de ejecutar. |
+| **Tailwind CSS** | Sistema de estilos donde se escriben pequeñas clases (`bg-blue-500 p-4`) directamente en HTML. El proyecto usa Tailwind v4. |
+| **shadcn/ui** | Biblioteca de componentes UI accesibles y personalizables (botones, diálogos, inputs) sobre Tailwind. |
+| **MDX** | Markdown con componentes React embebidos. Las descripciones de servicios y noticias están en MDX. |
+| **Frontmatter** | El bloque YAML arriba de un archivo MDX (entre `---`) con metadatos (título, fecha, tarifas). |
+| **MapLibre GL** | Biblioteca de mapas open source usada en `/map`. |
+| **Leaflet** | Biblioteca de mapas más simple, usada en el directorio de instalaciones. |
+| **NextAuth (Auth.js)** | Biblioteca que maneja login, sesiones y roles. |
+| **bcryptjs** | Biblioteca para hashear contraseñas de forma segura. La contraseña original nunca se almacena. |
+| **Zod** | Biblioteca para validar entradas de usuario en formularios. |
+| **next-intl** | Biblioteca que maneja los cuatro idiomas y las URLs con prefijo de idioma (`/ht/`, `/fr/`, `/en/`, `/es/`). |
+
+---
+
+## Términos de operación
+
+| Término | Significado |
+|---|---|
+| **Dominio** | Dirección web de un sitio, ej. `portal.ht`. Se compra a un registrador (Namecheap, Cloudflare, GoDaddy…). |
+| **Subdominio** | Nombre delante del dominio, ej. `jacmel.portal.ht`. Así identifica el portal a cada ciudad. |
+| **DNS comodín (wildcard)** | Registro DNS como `*.portal.ht` que coincide con *cualquier* subdominio. Esencial para añadir una ciudad sin tocar el DNS. |
+| **DNS** | La libreta de direcciones de internet. Asocia `jacmel.portal.ht` a la IP del servidor. |
+| **SSL / TLS / HTTPS** | El candado del navegador. Cifra el tráfico. Vercel lo provee gratis. |
+| **Hosting** | El servidor que corre el sitio en producción. El proyecto está pensado para Vercel (recomendado) pero corre donde sea que corra Node.js. |
+| **Vercel** | Plataforma de hosting de la empresa que hace Next.js. Plan gratuito disponible; planes pagos desde ~$20/mes. |
+| **Neon** | Servicio gestionado de PostgreSQL frecuentemente combinado con Vercel. Plan gratuito disponible. |
+| **Variable de entorno** | Valor de configuración (contraseña de la base, etc.) provisto a la app — nunca escrito en el código. Guardado en `.env.local` localmente, en el panel del hosting en producción. |
+| **CI / CD** | Integración Continua / Despliegue Continuo. Comprobaciones automáticas (lint, typecheck, build, tests) en cada PR. Definidas en `.github/workflows/ci.yml`. |
+| **Pull Request (PR)** | Propuesta de cambio de código, abierta en GitHub para revisión antes de fusionar. |
+| **Protección de rama** | Reglas de GitHub que impiden push directo a `main` y exigen revisiones en los PR. |
+| **Firma GPG** | Firmar criptográficamente tus commits para probar que vienen de ti. La protección de rama lo exige. |
+
+---
+
+## Términos específicos del proyecto
+
+| Término | Significado |
+|---|---|
+| **Tenant (inquilino)** | Una sola municipalidad/ciudad servida por el portal. Todo el proyecto está construido para que una sola app sirva muchos tenants. |
+| **SaaS multi-tenant** | Patrón donde una app sirve a muchas organizaciones distintas, con datos aislados. Haiti City Portal es multi-tenant: un mismo servidor puede servir Jacmel, Cap-Haïtien y Pétion-Ville a la vez. |
+| **`tenant_id`** | Columna UUID en cada fila de la base que dice a qué ciudad pertenece. Toda consulta debe filtrar por `tenant_id`. |
+| **Cabecera `x-tenant-subdomain`** | Cabecera HTTP interna que el middleware fija e indica al resto de la app de qué subdominio viene la petición. |
+| **UUID** | Identificador aleatorio de 128 bits, ej. `550e8400-e29b-41d4-a716-446655440000`. Clave primaria en todas las tablas — nunca enteros secuenciales. |
+| **Locale (configuración regional)** | Código de idioma: `en`, `fr`, `ht`, `es`. El default es `ht`. |
+| **Prefijo de locale** | La parte `/ht/` o `/en/` de una URL. Toda página pública vive bajo un prefijo. |
+| **Fallback de locale** | Si falta un archivo en francés, el portal usa silenciosamente el inglés. Permite traducir un idioma a la vez. |
+| **Código memo** | Código corto legible (ej. `JAC-TAX-8821`) mostrado al residente tras una solicitud de pago. Lo incluye como referencia en MonCash o transferencia para que un admin pueda conciliar. |
+| **Pending upload** | Estado de un pago cuyo código memo se emitió pero cuya recepción aún no fue confirmada por un admin. |
+| **Reconciliación manual** | Proceso actual donde un admin compara extractos bancarios/MonCash contra los pagos pendientes y los marca verificados. Se reemplazará luego con webhooks. |
+| **Solicitud de servicio** | Reporte o solicitud ciudadana — compatible con Open311. Almacenada en `service_requests`. |
+| **Reporte de campo** | Observación enviada por el personal desde el terreno. Distinta de una solicitud ciudadana. |
+| **Sección comunal** (término BD) | Fila en la tabla `communal_sections` que representa una subunidad geográfica; oficiales CASEC/ASEC se enlazan a una. |
+| **Handbook** | Artículos del manual de gobernanza interno (`handbook_articles`), visibles solo para admins con el rol correcto. |
+| **Snapshot de auditoría** | Copia congelada de cifras financieras en un momento para detectar manipulación posterior. |
+| **Alerta de emergencia** | Mensaje difundido a nivel de tenant (huracán, toque de queda, corte de agua). |
+
+---
+
+## Siglas
+
+| Sigla | Significa |
+|---|---|
+| **API** | Application Programming Interface |
+| **ADR** | Architecture Decision Record |
+| **BSL** | Business Source License |
+| **CI** | Continuous Integration |
+| **CD** | Continuous Deployment |
+| **CLA** | Contributor License Agreement |
+| **CMS** | Content Management System |
+| **DNS** | Domain Name System |
+| **GIS** | Geographic Information System |
+| **HCP** | Haiti City Portal |
+| **HTML** | HyperText Markup Language |
+| **HTTPS** | HyperText Transfer Protocol Secure |
+| **JSON** | JavaScript Object Notation |
+| **JSONB** | JSON, Binary |
+| **MDX** | Markdown + JSX |
+| **ORM** | Object-Relational Mapper |
+| **PR** | Pull Request |
+| **PRD** | Product Requirements Document |
+| **PWA** | Progressive Web App |
+| **RC** | Release Candidate |
+| **SaaS** | Software as a Service |
+| **SDK** | Software Development Kit |
+| **SQL** | Structured Query Language |
+| **SSL** | Secure Sockets Layer |
+| **TLS** | Transport Layer Security |
+| **UI** | User Interface |
+| **URL** | Uniform Resource Locator |
+| **UUID** | Universally Unique Identifier |
+| **YAML** | YAML Ain't Markup Language |
+
+---
+
+[↑ Volver arriba](#glosario) · [← Índice de documentación](README.es.md) · [README del proyecto →](../README.md)

--- a/docs/GLOSSARY.fr.md
+++ b/docs/GLOSSARY.fr.md
@@ -1,0 +1,158 @@
+<!--
+Langues : English (GLOSSARY.md) | Français (ce fichier) | Kreyòl (GLOSSARY.ht.md) | Español (GLOSSARY.es.md)
+-->
+
+**Langues :** [English](GLOSSARY.md) · **Français** · [Kreyòl Ayisyen](GLOSSARY.ht.md) · [Español](GLOSSARY.es.md)
+
+[← Index de la documentation](README.fr.md) · [README du projet](../README.md)
+
+---
+
+# Glossaire
+
+Définitions en langage clair de tous les termes techniques, civiques et propres à Haïti utilisés dans cette documentation. Si un mot vous bloque, cherchez-le ici. Si un terme manque, [ouvrez une Pull Request](https://github.com/haitiansintech/HaitiCityPortal/edit/main/docs/GLOSSARY.fr.md) ou [créez une issue](https://github.com/haitiansintech/HaitiCityPortal/issues/new/choose).
+
+## Sommaire
+
+- [Termes civiques et haïtiens](#termes-civiques-et-haïtiens)
+- [Termes techniques](#termes-techniques)
+- [Termes d'exploitation](#termes-dexploitation)
+- [Termes propres au projet](#termes-propres-au-projet)
+- [Sigles](#sigles)
+
+---
+
+## Termes civiques et haïtiens
+
+| Terme | Sens |
+|---|---|
+| **CASEC** | *Conseil d'Administration de la Section Communale*. Le conseil élu de trois personnes qui gouverne une *section communale*. |
+| **ASEC** | *Assemblée de la Section Communale*. L'assemblée législative élue d'une section communale, à côté du CASEC. |
+| **Commune** | Une municipalité en Haïti — équivalent d'une ville. Chaque commune a un maire ; c'est le niveau que dessert ce portail. |
+| **Section communale** | Sous-unité géographique d'une commune, gouvernée par un CASEC + ASEC. |
+| **Maire** | Chef élu d'une commune. |
+| **Délégué de ville** | Représentant nommé par le gouvernement central dans une commune. |
+| **MonCash** | Le service d'argent mobile le plus utilisé en Haïti, opéré par Digicel. Beaucoup de résidents paient leurs factures via MonCash. |
+| **NIF** | *Numéro d'Identification Fiscale*. Identifiant fiscal haïtien — requis pour la plupart des démarches officielles. |
+| **CIN** | *Carte d'Identification Nationale*. La carte d'identité nationale haïtienne. |
+| **Quittance** | Reçu ou preuve de paiement. Le portail émet une quittance lorsqu'un paiement est vérifié. |
+| **Open311** | Norme internationale ouverte permettant aux citoyens de signaler des problèmes non urgents (nids-de-poule, ordures, éclairage) à une municipalité. Le formulaire `/report` du portail suit cette norme. |
+
+---
+
+## Termes techniques
+
+| Terme | Sens |
+|---|---|
+| **Frontend** | Partie d'une application qui s'exécute dans le navigateur de l'utilisateur (pages, formulaires, boutons). |
+| **Backend** | Partie qui s'exécute sur un serveur : connexion, base de données, paiements. L'utilisateur ne voit jamais le code backend. |
+| **Full-stack** | Une application qui contient à la fois le frontend et le backend dans le même projet. Haiti City Portal est full-stack. |
+| **Next.js** | Le framework web sur lequel le projet est construit. Il produit à la fois les pages (frontend) et la logique serveur (backend) à partir d'un seul code. |
+| **App Router** | Le système de routage moderne de Next.js 13+ où chaque dossier sous `src/app/` devient une URL. |
+| **React** | La bibliothèque JavaScript qu'utilise Next.js pour construire les interfaces. |
+| **Server Component** | Page ou composant qui s'exécute côté serveur et envoie du HTML déjà prêt au navigateur. Plus rapide, meilleur pour le SEO, peut lire la base de données directement. |
+| **Client Component** | Composant qui s'exécute dans le navigateur. Nécessaire pour les éléments interactifs (cartes, formulaires, animations). Marqué par `"use client"` en haut du fichier. |
+| **Server Action** | Fonction backend appelable directement depuis un formulaire. Définie dans `src/app/actions/`. |
+| **API route** | Point d'accès backend à une URL comme `/api/health`. |
+| **Middleware** | Code qui s'exécute sur le serveur *avant* le rendu de la page. Ce projet l'utilise pour détecter la langue, identifier la ville (tenant) et protéger les pages admin. |
+| **Base de données** | Où sont stockées les données dynamiques : villes, utilisateurs, demandes, paiements, événements. |
+| **PostgreSQL (Postgres)** | Le moteur de base de données utilisé. Gratuit, open source, très répandu. |
+| **Drizzle ORM** | Outil qui permet d'écrire les requêtes en TypeScript plutôt qu'en SQL brut. Le schéma est dans `src/db/schema.ts`. |
+| **Schéma** | Plan de la base : quelles tables existent, quelles colonnes, quels types. |
+| **Migration** | Fichier qui met à jour le schéma (ajoute une colonne, renomme une table). Drizzle les génère. |
+| **Seeding** | Insérer des données de départ dans une base vide (ex. une ville de démo). Lancé avec `npm run db:seed`. |
+| **TypeScript** | Version de JavaScript avec vérification de types — détecte beaucoup d'erreurs avant l'exécution. |
+| **Tailwind CSS** | Système de styles où l'on écrit de petites classes (`bg-blue-500 p-4`) directement dans le HTML. Le projet utilise Tailwind v4. |
+| **shadcn/ui** | Bibliothèque de composants accessibles et personnalisables (boutons, boîtes de dialogue, champs) basés sur Tailwind. |
+| **MDX** | Markdown enrichi de composants React. Les descriptions de services et articles d'actualité sont en MDX. |
+| **Frontmatter** | Le bloc YAML en haut d'un fichier MDX (entre `---`) qui contient les métadonnées (titre, date, frais). |
+| **MapLibre GL** | Bibliothèque de cartes open source utilisée à `/map`. |
+| **Leaflet** | Bibliothèque de cartes plus simple, utilisée dans l'annuaire des installations. |
+| **NextAuth (Auth.js)** | Bibliothèque qui gère la connexion, les sessions et les rôles. |
+| **bcryptjs** | Bibliothèque pour hacher les mots de passe en sécurité. Le mot de passe original n'est jamais stocké. |
+| **Zod** | Bibliothèque de validation des saisies utilisateur. |
+| **next-intl** | Bibliothèque qui gère les quatre langues et les URLs préfixées (`/ht/`, `/fr/`, `/en/`, `/es/`). |
+
+---
+
+## Termes d'exploitation
+
+| Terme | Sens |
+|---|---|
+| **Domaine** | Adresse web d'un site, par exemple `portal.ht`. Acheté chez un bureau d'enregistrement (Namecheap, Cloudflare, GoDaddy…). |
+| **Sous-domaine** | Préfixe d'un domaine, par exemple `jacmel.portal.ht`. C'est ainsi que ce portail identifie la ville. |
+| **DNS wildcard (joker)** | Enregistrement DNS comme `*.portal.ht` qui correspond à *n'importe quel* sous-domaine. Indispensable pour ajouter une ville sans toucher au DNS. |
+| **DNS** | Le carnet d'adresses d'Internet. Associe `jacmel.portal.ht` à l'IP du serveur. |
+| **SSL / TLS / HTTPS** | Le cadenas dans le navigateur. Chiffre le trafic. Vercel l'offre gratuitement. |
+| **Hébergement** | Le serveur qui fait tourner le site en production. Le projet est conçu pour Vercel (recommandé) mais marche partout où tourne Node.js. |
+| **Vercel** | Plateforme d'hébergement de la société qui édite Next.js. Gratuit jusqu'à un certain volume ; plans payants à partir de ~20 $/mois. |
+| **Neon** | Service PostgreSQL géré, souvent associé à Vercel. Plan gratuit disponible. |
+| **Variable d'environnement** | Valeur de configuration (mot de passe de la base, etc.) fournie à l'application — jamais inscrite dans le code. Stockée dans `.env.local` localement, dans le tableau de bord de l'hébergeur en production. |
+| **CI / CD** | Intégration continue / Déploiement continu. Vérifications automatiques (lint, typecheck, build, tests) à chaque PR. Définies dans `.github/workflows/ci.yml`. |
+| **Pull Request (PR)** | Proposition de changement de code, ouverte sur GitHub pour relecture avant fusion. |
+| **Protection de branche** | Règles GitHub interdisant les push directs sur `main` et exigeant des relectures sur les PR. |
+| **Signature GPG** | Signer cryptographiquement ses commits pour prouver qu'ils viennent bien de vous. Exigée par la protection de branche. |
+
+---
+
+## Termes propres au projet
+
+| Terme | Sens |
+|---|---|
+| **Tenant (locataire)** | Une seule municipalité/ville desservie par le portail. Le projet est bâti pour qu'une seule application en serve plusieurs. |
+| **SaaS multi-tenant** | Modèle où une seule application sert plusieurs organisations distinctes, leurs données isolées. Haiti City Portal est multi-tenant : un même serveur peut faire tourner Jacmel, Cap-Haïtien et Pétion-Ville à la fois. |
+| **`tenant_id`** | Colonne UUID sur chaque ligne de la base disant à quelle ville la ligne appartient. Chaque requête doit filtrer par `tenant_id`. |
+| **En-tête `x-tenant-subdomain`** | En-tête HTTP interne posé par le middleware qui dit au reste de l'application de quel sous-domaine vient la requête. |
+| **UUID** | Identifiant aléatoire de 128 bits (par ex. `550e8400-e29b-41d4-a716-446655440000`). Utilisé comme clé primaire de toutes les tables — jamais des entiers séquentiels. |
+| **Locale** | Code de langue : `en` (anglais), `fr` (français), `ht` (créole haïtien), `es` (espagnol). Locale par défaut : `ht`. |
+| **Préfixe de locale** | La partie `/ht/` ou `/en/` d'une URL. Toutes les pages publiques vivent sous un préfixe. |
+| **Repli de locale** | Si un fichier français manque, le portail utilise silencieusement le fichier anglais. Permet de publier une langue à la fois. |
+| **Code mémo** | Code court lisible (par ex. `JAC-TAX-8821`) montré au résident après une demande de paiement. Il l'utilise comme référence dans MonCash ou son virement pour qu'un admin puisse rapprocher la somme. |
+| **Pending upload** | Statut d'un paiement dont le code mémo a été émis mais dont la réception n'a pas encore été confirmée par un admin. |
+| **Réconciliation manuelle** | Processus actuel où un admin compare les relevés bancaires/MonCash aux paiements en attente du portail et les marque vérifiés. Sera remplacé plus tard par des webhooks. |
+| **Demande de service** | Signalement ou demande citoyenne — compatible Open311. Stockée dans `service_requests`. |
+| **Rapport de terrain** | Observation soumise par le personnel depuis le terrain. Distinct d'une demande citoyenne. |
+| **Section communale** (terme BD) | Ligne de la table `communal_sections` représentant une sous-unité géographique ; CASEC/ASEC y sont liés. |
+| **Handbook** | Articles internes du manuel de gouvernance (`handbook_articles`), visibles seulement par les admins du bon rôle. |
+| **Snapshot d'audit** | Copie figée des chiffres financiers à un instant T pour détecter une falsification ultérieure. |
+| **Alerte d'urgence** | Message diffusé à l'échelle d'un tenant (ouragan, couvre-feu, coupure d'eau). |
+
+---
+
+## Sigles
+
+| Sigle | Signification |
+|---|---|
+| **API** | Application Programming Interface |
+| **ADR** | Architecture Decision Record |
+| **BSL** | Business Source License |
+| **CI** | Continuous Integration |
+| **CD** | Continuous Deployment |
+| **CLA** | Contributor License Agreement |
+| **CMS** | Content Management System |
+| **DNS** | Domain Name System |
+| **GIS** | Geographic Information System |
+| **HCP** | Haiti City Portal |
+| **HTML** | HyperText Markup Language |
+| **HTTPS** | HyperText Transfer Protocol Secure |
+| **JSON** | JavaScript Object Notation |
+| **JSONB** | JSON, Binary |
+| **MDX** | Markdown + JSX |
+| **ORM** | Object-Relational Mapper |
+| **PR** | Pull Request |
+| **PRD** | Product Requirements Document |
+| **PWA** | Progressive Web App |
+| **RC** | Release Candidate |
+| **SaaS** | Software as a Service |
+| **SDK** | Software Development Kit |
+| **SQL** | Structured Query Language |
+| **SSL** | Secure Sockets Layer |
+| **TLS** | Transport Layer Security |
+| **UI** | User Interface |
+| **URL** | Uniform Resource Locator |
+| **UUID** | Universally Unique Identifier |
+| **YAML** | YAML Ain't Markup Language |
+
+---
+
+[↑ Retour en haut](#glossaire) · [← Index de la documentation](README.fr.md) · [README du projet →](../README.md)

--- a/docs/GLOSSARY.ht.md
+++ b/docs/GLOSSARY.ht.md
@@ -1,0 +1,158 @@
+<!--
+Lang yo: English (GLOSSARY.md) | Français (GLOSSARY.fr.md) | Kreyòl (fichye sa a) | Español (GLOSSARY.es.md)
+-->
+
+**Lang yo:** [English](GLOSSARY.md) · [Français](GLOSSARY.fr.md) · **Kreyòl Ayisyen** · [Español](GLOSSARY.es.md)
+
+[← Endèks dokimantasyon](README.ht.md) · [README pwojè a](../README.md)
+
+---
+
+# Glosè
+
+Definisyon an lang senp pou tout tèm teknik, sivik, ak espesifik pou Ayiti yo itilize nan dokimantasyon sa a. Si yon mo bloke w nan yon dokiman, gade isit la. Si yon tèm manke, [louvri yon Pull Request](https://github.com/haitiansintech/HaitiCityPortal/edit/main/docs/GLOSSARY.ht.md) oswa [yon issue](https://github.com/haitiansintech/HaitiCityPortal/issues/new/choose).
+
+## Tablo Kontni
+
+- [Tèm sivik ak ayisyen](#tèm-sivik-ak-ayisyen)
+- [Tèm teknik](#tèm-teknik)
+- [Tèm operasyon](#tèm-operasyon)
+- [Tèm espesifik pou pwojè a](#tèm-espesifik-pou-pwojè-a)
+- [Akwonim](#akwonim)
+
+---
+
+## Tèm sivik ak ayisyen
+
+| Tèm | Sans |
+|---|---|
+| **CASEC** | *Conseil d'Administration de la Section Communale*. Konsèy twa moun ki eli pou dirije yon *seksyon kominal*. |
+| **ASEC** | *Assemblée de la Section Communale*. Asanble lejislatif eli yon seksyon kominal, akote CASEC la. |
+| **Komin** | Yon minisipalite an Ayiti — menm bagay ak yon vil. Chak komin gen yon majistra; se nivo gouvènman sa a pòtal sa a sèvi. |
+| **Seksyon kominal** | Sou-inite jeyografik nan yon komin, jere pa yon CASEC + ASEC. |
+| **Majistra** | Chèf eli yon komin. |
+| **Delege Vil** | Reprezantan gouvènman santral nonmen nan yon komin. |
+| **MonCash** | Sèvis lajan mobil ki pi itilize an Ayiti, jere pa Digicel. Anpil rezidan peye fakti yo pa MonCash. |
+| **NIF** | *Numéro d'Identification Fiscale*. Nimewo idantifikasyon fiskal ayisyen — egzije pou pifò demach ofisyèl. |
+| **CIN** | *Carte d'Identification Nationale*. Kat idantite nasyonal ayisyen. |
+| **Kitans / Quittance** | Resi oswa prèv peyman. Pòtal la bay yon kitans lè yon peyman verifye. |
+| **Open311** | Estanda entènasyonal louvri ki pèmèt sitwayen siyale pwoblèm ki pa ijans (twou nan wout, fatra, limyè) bay minisipalite. Fòm `/report` pòtal la swiv estanda sa a. |
+
+---
+
+## Tèm teknik
+
+| Tèm | Sans |
+|---|---|
+| **Frontend** | Pati nan yon aplikasyon ki kouri nan navigatè itilizatè a (paj, fòm, bouton). |
+| **Backend** | Pati ki kouri sou yon sèvè: koneksyon, baz done, peyman. Itilizatè a pa janm wè kòd backend. |
+| **Full-stack** | Yon aplikasyon ki gen tou de frontend ak backend nan menm pwojè a. Haiti City Portal se full-stack. |
+| **Next.js** | Framework web pwojè a baze sou. Li bay tou de paj (frontend) ak lojik sèvè (backend) soti nan yon sèl kòd. |
+| **App Router** | Sistèm routaj modèn nan Next.js 13+ kote chak dosye anba `src/app/` vin yon URL. |
+| **React** | Bibliyotèk JavaScript Next.js itilize pou bati entèfas. |
+| **Server Component** | Paj oswa konpozan ki kouri sou sèvè a epi voye HTML deja pare nan navigatè a. Pi rapid, pi bon pou SEO, ka li baz done dirèkteman. |
+| **Client Component** | Konpozan ki kouri nan navigatè a. Bezwen pou bagay entèraktif (kat, fòm, animasyon). Make ak `"use client"` an wo fichye a. |
+| **Server Action** | Fonksyon backend ou ka rele dirèkteman soti nan yon fòm. Defini nan `src/app/actions/`. |
+| **API route** | Pwen bakend nan yon URL tankou `/api/health`. |
+| **Middleware** | Kòd ki kouri sou sèvè a *anvan* yon paj rann. Pwojè sa a sèvi avè l pou detekte lang, idantifye vil (tenant), ak pwoteje paj admin. |
+| **Baz done** | Kote done dinamik yo estoke: vil, itilizatè, demann sèvis, peyman, evènman. |
+| **PostgreSQL (Postgres)** | Motè baz done a. Gratis, kòd louvri, anpil itilize. |
+| **Drizzle ORM** | Zouti ki pèmèt devlopè ekri rekèt nan TypeScript olye SQL kri. Schema a nan `src/db/schema.ts`. |
+| **Schema** | Plan baz done a — ki tab egziste, ki kolòn, ki tip. |
+| **Migrasyon** | Fichye ki met schema a ajou (ajoute yon kolòn, chanje non yon tab). Drizzle jenere yo. |
+| **Seeding** | Mete done depa nan yon baz vid (egzanp, yon vil demo). Lanse ak `npm run db:seed`. |
+| **TypeScript** | Vèsyon JavaScript ak verifikasyon tip — kenbe anpil bug anvan kòd la kouri. |
+| **Tailwind CSS** | Sistèm style kote w ekri ti klas (`bg-blue-500 p-4`) dirèkteman nan HTML. Pwojè a itilize Tailwind v4. |
+| **shadcn/ui** | Bibliyotèk konpozan UI aksesib epi pèsonalizab (bouton, dyalòg, antre) bati sou Tailwind. |
+| **MDX** | Markdown ak konpozan React anndan. Deskripsyon sèvis ak atik nouvèl ekri an MDX. |
+| **Frontmatter** | Blòk YAML an wo yon fichye MDX (ant `---`) ki gen metadone (tit, dat, frè). |
+| **MapLibre GL** | Bibliyotèk kat kòd louvri itilize nan `/map`. |
+| **Leaflet** | Bibliyotèk kat pi senp, itilize nan ane riye etablisman yo. |
+| **NextAuth (Auth.js)** | Bibliyotèk ki jere koneksyon, sesyon, ak wòl. |
+| **bcryptjs** | Bibliyotèk pou hash modpas an sekirite. Modpas orijinal pa janm estoke. |
+| **Zod** | Bibliyotèk pou valide done itilizatè antre nan fòm. |
+| **next-intl** | Bibliyotèk ki jere kat lang yo ak URL prefiks-lokal (`/ht/`, `/fr/`, `/en/`, `/es/`). |
+
+---
+
+## Tèm operasyon
+
+| Tèm | Sans |
+|---|---|
+| **Domèn** | Adrès web yon sit, egzanp `portal.ht`. Achte nan yon biwo enskripsyon (Namecheap, Cloudflare, GoDaddy…). |
+| **Soudomèn** | Non devan yon domèn, egzanp `jacmel.portal.ht`. Se konsa pòtal la idantifye ki vil. |
+| **DNS wildcard (joker)** | Yon antre DNS tankou `*.portal.ht` ki matche *nenpòt* soudomèn. Esansyèl pou ajoute yon nouvo vil san chanje DNS la. |
+| **DNS** | Liv adrès Entènèt la. Marye `jacmel.portal.ht` ak adrès IP sèvè a. |
+| **SSL / TLS / HTTPS** | Kadna nan navigatè a. Kripte trafik. Vercel bay li gratis. |
+| **Hosting (ebèjman)** | Sèvè ki fè sit pwodiksyon an mache. Pwojè a fèt pou Vercel (rekòmande) men li mache nenpòt kote Node.js mache. |
+| **Vercel** | Platfòm ebèjman bati pa konpayi ki fè Next.js. Plan gratis disponib; plan peye kòmanse $20/mwa. |
+| **Neon** | Sèvis PostgreSQL jere souvan parye ak Vercel. Plan gratis disponib. |
+| **Varyab anviwònman** | Valè konfigirasyon (modpas baz done, elatriye) bay aplikasyon an — pa janm ekri nan kòd. Estoke nan `.env.local` lokalman, nan tablobò ebèjè a pou pwodiksyon. |
+| **CI / CD** | Entegrasyon Kontinyèl / Deplwaman Kontinyèl. Verifikasyon otomatik (lint, typecheck, build, tès) sou chak PR. Defini nan `.github/workflows/ci.yml`. |
+| **Pull Request (PR)** | Pwopozisyon chanjman kòd, louvri sou GitHub pou revizyon anvan fizyon. |
+| **Pwoteksyon branch** | Règ GitHub ki anpeche push dirèk sou `main` epi mande revizyon sou PR. |
+| **Siyati GPG** | Siyen kriptografikman commits ou pou prouve yo soti nan men ou vrèman. Egzije pa pwoteksyon branch lan. |
+
+---
+
+## Tèm espesifik pou pwojè a
+
+| Tèm | Sans |
+|---|---|
+| **Tenant** | Yon sèl minisipalite/vil sèvi pa pòtal la. Tout pwojè a fèt pou yon sèl aplikasyon ka sèvi anpil tenant. |
+| **SaaS multi-tenant** | Modèl kote yon sèl aplikasyon sèvi anpil òganizasyon diferan, done yo izole. Haiti City Portal multi-tenant: yon sèl sèvè ka fè Jacmel, Cap-Haïtien, ak Pétion-Ville mache anmenmtan. |
+| **`tenant_id`** | Kolòn UUID sou chak liy nan baz done a ki di a ki vil liy lan apatni. Chak rekèt dwe filtre pa `tenant_id`. |
+| **Antèt `x-tenant-subdomain`** | Antèt HTTP entèn middleware a mete ki di rès aplikasyon an ki soudomèn vil rekèt aktyèl la soti. |
+| **UUID** | Idantifyan aleatwa 128 bit tankou `550e8400-e29b-41d4-a716-446655440000`. Itilize kòm kle prensipal sou tout tab — pa janm antye sekansyèl. |
+| **Lokal** | Kòd lang: `en` (anglè), `fr` (franse), `ht` (kreyòl ayisyen), `es` (espanyòl). Lokal default: `ht`. |
+| **Prefiks lokal** | Pati `/ht/` oswa `/en/` nan yon URL. Tout paj piblik anba yon prefiks. |
+| **Sekou lokal (locale fallback)** | Si yon fichye franse manke, pòtal la itilize fichye anglè a san pwoblèm. Pèmèt tradiktè liberasyon yon lang nan yon fwa. |
+| **Kòd memo** | Kòd kout lizib (egzanp `JAC-TAX-8821`) montre yon rezidan apre yon demann peyman. Yo itilize l kòm referans nan MonCash oswa transfè bankè pou yon admin ka rekonsilye lajan an. |
+| **Pending upload** | Estati yon peyman ki gen kòd memo bay men resepsyon pa ankò konfime pa yon admin. |
+| **Rekonsilyasyon manyèl** | Pwosesis aktyèl kote yon admin konpare relve labank/MonCash ak peyman annatant nan pòtal la epi make yo verifye. Ap ranplase pita ak webhooks. |
+| **Demann sèvis** | Rapò oswa demann yon sitwayen — konpatib Open311. Estoke nan `service_requests`. |
+| **Rapò teren** | Obsèvasyon yon staf soti depi sou teren. Diferan ak demann sèvis. |
+| **Seksyon kominal** (tèm BD) | Liy nan tab `communal_sections` ki reprezante yon sou-inite jeyografik; ofisyèl CASEC/ASEC lye ak yon sèl. |
+| **Handbook** | Atik manyèl gouvènans entèn (`handbook_articles`), vizib sèlman pou admin ki gen bon wòl la. |
+| **Snapshot odit** | Kopi chif finansyè nan yon moman pou detekte falsifikasyon apre. |
+| **Alèt ijans** | Mesaj difize sou nivo yon tenant (siklòn, kouvrefe, koupire dlo). |
+
+---
+
+## Akwonim
+
+| Akwonim | Vle di |
+|---|---|
+| **API** | Application Programming Interface |
+| **ADR** | Architecture Decision Record |
+| **BSL** | Business Source License |
+| **CI** | Continuous Integration |
+| **CD** | Continuous Deployment |
+| **CLA** | Contributor License Agreement |
+| **CMS** | Content Management System |
+| **DNS** | Domain Name System |
+| **GIS** | Geographic Information System |
+| **HCP** | Haiti City Portal |
+| **HTML** | HyperText Markup Language |
+| **HTTPS** | HyperText Transfer Protocol Secure |
+| **JSON** | JavaScript Object Notation |
+| **JSONB** | JSON, Binary |
+| **MDX** | Markdown + JSX |
+| **ORM** | Object-Relational Mapper |
+| **PR** | Pull Request |
+| **PRD** | Product Requirements Document |
+| **PWA** | Progressive Web App |
+| **RC** | Release Candidate |
+| **SaaS** | Software as a Service |
+| **SDK** | Software Development Kit |
+| **SQL** | Structured Query Language |
+| **SSL** | Secure Sockets Layer |
+| **TLS** | Transport Layer Security |
+| **UI** | User Interface |
+| **URL** | Uniform Resource Locator |
+| **UUID** | Universally Unique Identifier |
+| **YAML** | YAML Ain't Markup Language |
+
+---
+
+[↑ Retounen anwo](#glosè) · [← Endèks dokimantasyon](README.ht.md) · [README pwojè a →](../README.md)

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,158 @@
+<!--
+Languages: English (this file) | Français (GLOSSARY.fr.md) | Kreyòl (GLOSSARY.ht.md) | Español (GLOSSARY.es.md)
+-->
+
+**Languages:** **English** · [Français](GLOSSARY.fr.md) · [Kreyòl Ayisyen](GLOSSARY.ht.md) · [Español](GLOSSARY.es.md)
+
+[← Docs index](README.md) · [Project README](../README.md)
+
+---
+
+# Glossary
+
+Plain-language definitions of every technical, civic, and Haitian-specific term used in this project's documentation. If a word in any document confuses you, look it up here. If a term is missing, please [open a Pull Request](https://github.com/haitiansintech/HaitiCityPortal/edit/main/docs/GLOSSARY.md) or [file an issue](https://github.com/haitiansintech/HaitiCityPortal/issues/new/choose).
+
+## Table of Contents
+
+- [Civic and Haitian terms](#civic-and-haitian-terms)
+- [Technology terms](#technology-terms)
+- [Operations terms](#operations-terms)
+- [Project-specific terms](#project-specific-terms)
+- [Acronyms](#acronyms)
+
+---
+
+## Civic and Haitian terms
+
+| Term | Meaning |
+|---|---|
+| **CASEC** | *Conseil d'Administration de la Section Communale*. The elected three-person council that governs a *communal section* (the smallest administrative unit in Haiti, smaller than a commune). |
+| **ASEC** | *Assemblée de la Section Communale*. The elected legislative assembly of a communal section, alongside CASEC. |
+| **Commune** | A municipality in Haiti — equivalent to a city or town. Each commune has a mayor and is the level of government this portal serves. |
+| **Communal section** (*Section Communale*) | A sub-municipal geographic unit. A commune is divided into communal sections; each section is governed by a CASEC + ASEC. |
+| **Mayor** (*Majistra*) | The elected head of a commune. |
+| **Town Delegate** (*Délégué de ville*) | An appointed central-government representative in a commune. |
+| **MonCash** | Haiti's most-used mobile money service, operated by Digicel. Many residents pay bills through MonCash. |
+| **NIF** | *Numéro d'Identification Fiscale*. The Haitian taxpayer identification number — required for most official transactions. |
+| **CIN** | *Carte d'Identification Nationale*. The Haitian national identity card. |
+| **Quittance** (Fr/Kreyòl) | A receipt or proof of payment. The portal issues a *quittance* when a payment is verified. |
+| **Open311** | An open international standard for citizens to report non-emergency issues (potholes, garbage, lighting) to a municipality. The portal's `/report` form follows this standard. |
+
+---
+
+## Technology terms
+
+| Term | Meaning |
+|---|---|
+| **Frontend** | The part of an application that runs in the user's browser and displays pages, forms, and buttons. |
+| **Backend** | The part of an application that runs on a server: handles login, queries the database, processes payments. The user never sees backend code directly. |
+| **Full-stack** | An application or codebase that contains both frontend and backend in the same project. Haiti City Portal is full-stack. |
+| **Next.js** | The web framework this project is built on. It produces both the frontend pages and the backend logic from one codebase. |
+| **App Router** | The modern routing system in Next.js 13+ where each folder under `src/app/` becomes a URL. |
+| **React** | The JavaScript library Next.js uses to build user interfaces (pages and components). |
+| **Server Component** | A page or component that runs on the server and sends finished HTML to the browser. Faster, better for SEO, can read the database directly. |
+| **Client Component** | A component that runs in the browser. Needed for interactive things (maps, form state, animations). Marked with `"use client"` at the top of the file. |
+| **Server Action** | A backend function you can call directly from a form. Defined in `src/app/actions/`. |
+| **API route** | A backend endpoint at a URL like `/api/health`. Used by external systems or browser scripts to send/receive data. |
+| **Middleware** | Code that runs on the server *before* a page renders. This project uses middleware to detect the language, identify the city (tenant), and protect admin pages. |
+| **Database** | Where dynamic data is stored: cities, users, service requests, payments, events. |
+| **PostgreSQL (Postgres)** | The specific database engine used. Free, open source, very widely deployed. |
+| **Drizzle ORM** | The tool that lets developers write database queries in TypeScript instead of raw SQL. The schema is in `src/db/schema.ts`. |
+| **Schema** | The blueprint of the database — what tables exist, what columns each has, what types they hold. |
+| **Migration** | A file that updates the schema (adds a column, renames a table). Drizzle generates these. |
+| **Seeding** | Inserting starter data into a fresh database (e.g. one demo city). Run with `npm run db:seed`. |
+| **TypeScript** | A version of JavaScript with type checking — catches many bugs before the code runs. |
+| **Tailwind CSS** | A styling system where you write small classes (like `bg-blue-500 p-4`) directly in HTML. The project uses Tailwind v4. |
+| **shadcn/ui** | A library of accessible, customisable UI components (buttons, dialogs, inputs) built on Tailwind. |
+| **MDX** | Markdown with embedded React components. Service descriptions and news articles are written in MDX files. |
+| **Frontmatter** | The YAML block at the top of an MDX file (between `---` markers) that holds structured metadata (title, date, fees). |
+| **MapLibre GL** | The open-source JavaScript map library used at `/map`. |
+| **Leaflet** | A simpler open-source map library used in the facilities directory. |
+| **NextAuth (Auth.js)** | The library that handles login, sessions, and user roles. |
+| **bcryptjs** | A library for securely hashing passwords. The original password is never stored. |
+| **Zod** | A library for validating user input on forms (so a phone field actually contains a phone number). |
+| **next-intl** | The library that handles the four languages and locale-prefixed URLs (`/ht/`, `/fr/`, `/en/`, `/es/`). |
+
+---
+
+## Operations terms
+
+| Term | Meaning |
+|---|---|
+| **Domain** | The web address of a site, e.g. `portal.ht`. You buy a domain from a registrar (Namecheap, Cloudflare, GoDaddy, etc.). |
+| **Subdomain** | A name in front of the domain, e.g. `jacmel.portal.ht`. Subdomains are how this portal identifies which city is being served. |
+| **Wildcard DNS** | A DNS record like `*.portal.ht` that matches *any* subdomain. Required so that adding a new city doesn't require IT changes. |
+| **DNS** | The internet's address book. Maps `jacmel.portal.ht` to the server's IP address. |
+| **SSL / TLS / HTTPS** | The padlock in your browser. Encrypts traffic. Hosting providers like Vercel give you HTTPS for free. |
+| **Hosting** | The server that runs the live site. This project is designed to run on Vercel (recommended), but works anywhere Node.js runs. |
+| **Vercel** | A hosting platform built by the company that makes Next.js. Free tier available; paid plans start around $20/month. |
+| **Neon** | A managed PostgreSQL database service often paired with Vercel. Free tier available. |
+| **Environment variable** | A configuration value (like the database password) provided to the running app — never written into the code. Stored in `.env.local` for local dev, in the hosting dashboard for production. |
+| **CI / CD** | Continuous Integration / Continuous Deployment. Automated checks (lint, typecheck, build, tests) that run on every Pull Request. Defined in `.github/workflows/ci.yml`. |
+| **Pull Request (PR)** | A proposed change to the code, opened on GitHub for review before merging. |
+| **Branch protection** | GitHub rules preventing direct pushes to `main` and requiring reviews on PRs. |
+| **GPG signing** | Cryptographically signing your commits to prove they are really from you. Required by this project's branch protection. |
+
+---
+
+## Project-specific terms
+
+| Term | Meaning |
+|---|---|
+| **Tenant** | A single municipality / city served by the portal. The whole project is built so one running app can serve many tenants. |
+| **Multi-tenant SaaS** | A pattern where one running application serves many separate organisations, with their data isolated. Haiti City Portal is multi-tenant: one server can run Jacmel, Cap-Haïtien, and Pétion-Ville at once. |
+| **`tenant_id`** | The UUID column on every database row that says which city the row belongs to. Every database query must filter by `tenant_id`. |
+| **`x-tenant-subdomain` header** | An internal HTTP header set by the middleware that tells the rest of the app which city's subdomain the current request came from. |
+| **UUID** | A 128-bit random identifier like `550e8400-e29b-41d4-a716-446655440000`. Used as the primary key on every table — never sequential integers. |
+| **Locale** | A language code: `en` (English), `fr` (French), `ht` (Haitian Creole), `es` (Spanish). The default locale is `ht`. |
+| **Locale prefix** | The `/ht/` or `/en/` part of a URL. Every public page lives under a locale prefix. |
+| **Locale fallback** | If a French file is missing, the portal silently uses the English file. Lets translators ship one language at a time. |
+| **Memo code** | A short human-readable code (e.g. `JAC-TAX-8821`) shown to a resident after they submit a payment. They include this code with their MonCash or wire transfer so an admin can match the money to the request. |
+| **Pending upload** | The status of a payment whose memo code has been issued but whose actual payment has not yet been confirmed by an admin. |
+| **Manual reconciliation** | The current process where an admin compares bank/MonCash statements against the portal's pending payments and marks each one verified. Will be replaced by webhooks later. |
+| **Service request** | A citizen's report or service application — Open311-compatible. Stored in the `service_requests` table. |
+| **Field report** | A staff-submitted observation from the field (e.g. flooded street, damaged building). Different from a service request. |
+| **Communal section** (DB term) | A row in the `communal_sections` table representing a sub-municipal geographic unit; CASEC/ASEC officials are linked to one. |
+| **Handbook** | The internal governance handbook articles (`handbook_articles` table) visible only to admin users with the right role. |
+| **Audit snapshot** | A point-in-time copy of finance figures used to detect after-the-fact tampering. |
+| **Emergency alert** | A tenant-scoped broadcast message (hurricane, curfew, water cut). |
+
+---
+
+## Acronyms
+
+| Acronym | Stands for |
+|---|---|
+| **API** | Application Programming Interface |
+| **ADR** | Architecture Decision Record |
+| **BSL** | Business Source License |
+| **CI** | Continuous Integration |
+| **CD** | Continuous Deployment |
+| **CLA** | Contributor License Agreement |
+| **CMS** | Content Management System |
+| **DNS** | Domain Name System |
+| **GIS** | Geographic Information System |
+| **HCP** | Haiti City Portal |
+| **HTML** | HyperText Markup Language |
+| **HTTPS** | HyperText Transfer Protocol Secure |
+| **JSON** | JavaScript Object Notation |
+| **JSONB** | JSON, Binary (PostgreSQL's efficient JSON storage) |
+| **MDX** | Markdown + JSX |
+| **ORM** | Object-Relational Mapper |
+| **PR** | Pull Request |
+| **PRD** | Product Requirements Document |
+| **PWA** | Progressive Web App |
+| **RC** | Release Candidate |
+| **SaaS** | Software as a Service |
+| **SDK** | Software Development Kit |
+| **SQL** | Structured Query Language |
+| **SSL** | Secure Sockets Layer |
+| **TLS** | Transport Layer Security |
+| **UI** | User Interface |
+| **URL** | Uniform Resource Locator |
+| **UUID** | Universally Unique Identifier |
+| **YAML** | YAML Ain't Markup Language (used for frontmatter) |
+
+---
+
+[↑ Back to top](#glossary) · [← Docs index](README.md) · [Project README →](../README.md)

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,0 +1,130 @@
+<!--
+Idiomas: English (README.md) | Français (README.fr.md) | Kreyòl (README.ht.md) | Español (este archivo)
+-->
+
+**Idiomas:** [English](README.md) · [Français](README.fr.md) · [Kreyòl Ayisyen](README.ht.md) · **Español**
+
+[← Volver al README del proyecto](../README.md)
+
+---
+
+# Haiti City Portal — Documentación
+
+Bienvenido/a. Este índice es la puerta de entrada a todos los documentos del proyecto. Elija el documento que corresponda a su rol — no necesita leerlo todo.
+
+## Índice
+
+- [Empiece aquí según su rol](#empiece-aquí-según-su-rol)
+- [Todos los documentos](#todos-los-documentos)
+- [Orden de lectura para un nuevo colaborador](#orden-de-lectura-para-un-nuevo-colaborador)
+- [Orden de lectura para una municipalidad](#orden-de-lectura-para-una-municipalidad)
+- [Cómo proponer un cambio](#cómo-proponer-un-cambio)
+- [Sobre las traducciones](#sobre-las-traducciones)
+
+---
+
+## Empiece aquí según su rol
+
+| Si usted es… | Comience por |
+|---|---|
+| **Alcalde, concejal o personal municipal** evaluando esto para su municipalidad | [Para Municipalidades](FOR_MUNICIPALITIES.es.md) |
+| **Desarrollador** que quiere contribuir código | [Arquitectura](ARCHITECTURE.es.md) → [Notas técnicas](technical-notes.md) → [Contribuir](../CONTRIBUTING.md) |
+| **Administrador de sistemas / informático** que debe desplegar esto | [Despliegue](DEPLOYMENT.es.md) → [Alta de Municipio](TENANT_ONBOARDING.es.md) |
+| **Personal municipal** que usará el panel de administración | [Manual de Administración](ADMIN_MANUAL.es.md) |
+| **Traductor o editor de contenido** (sin programar) | [Guía de Contenido](CONTENT_GUIDE.es.md) |
+| **Ciudadano** con curiosidad sobre qué es el proyecto | [Para Municipalidades](FOR_MUNICIPALITIES.es.md) (sección "Qué es") |
+| **No entiende una palabra** en algún documento | [Glosario](GLOSSARY.es.md) |
+
+---
+
+## Todos los documentos
+
+### Visiones generales en lenguaje claro
+
+| Documento | Propósito |
+|---|---|
+| [Para Municipalidades](FOR_MUNICIPALITIES.es.md) | No técnico: qué es, qué necesita, cuánto cuesta, a quién contactar |
+| [Glosario](GLOSSARY.es.md) | Definiciones claras de cada término técnico y cívico haitiano usado |
+| [Código de Conducta](../CODE_OF_CONDUCT.es.md) | Conducta esperada de colaboradores y miembros de la comunidad |
+
+### Operaciones (desplegar y operar el portal)
+
+| Documento | Propósito |
+|---|---|
+| [Despliegue](DEPLOYMENT.es.md) | Paso a paso: dominio, DNS, hosting, base de datos, variables, primer despliegue |
+| [Alta de Municipio](TENANT_ONBOARDING.es.md) | Cómo agregar una ciudad: crear el tenant, subdominio, marca, oficiales, primer admin |
+| [Manual de Administración](ADMIN_MANUAL.es.md) | Cómo el personal usa el panel día a día |
+| [Guía de Contenido](CONTENT_GUIDE.es.md) | Traducir o editar contenido vía la web de GitHub (sin Git ni código) |
+| [Protección de Rama](BRANCH_PROTECTION.md) | Configuración de la rama `main` para administradores del repositorio |
+
+### Ingeniería
+
+| Documento | Propósito |
+|---|---|
+| [Arquitectura](ARCHITECTURE.es.md) | Vista general de una página con diagrama |
+| [Notas técnicas](technical-notes.md) | Detalle: tenants, contenido, autenticación, pagos, mapas |
+| [Requisitos de Producto (PRD)](haiti-city-portal-prd.md) | Lista completa de funciones y usuarios objetivo |
+| [Estado de Implementación](v0.1-implementation-plan.md) | Inventario marcable de lo construido y lo pendiente |
+| [Registros de Decisiones de Arquitectura (ADR)](adr/README.es.md) | El "por qué" detrás de las decisiones técnicas mayores |
+| [Instrucciones Copilot](../copilot-instructions.md) | Reglas estrictas para asistentes de IA y colaboradores |
+
+### Política
+
+| Documento | Propósito |
+|---|---|
+| [Política de Seguridad](../SECURITY.md) | Cómo reportar una vulnerabilidad y el modelo de seguridad |
+| [Contribuir](../CONTRIBUTING.md) | Cómo hacer fork, contribuir código y traducir |
+| [Licencia](../LICENSE.md) | Business Source License 1.1 (se convierte en Apache 2.0 el 31 de diciembre de 2028) |
+
+---
+
+## Orden de lectura para un nuevo colaborador
+
+Si quiere escribir código en este proyecto:
+
+1. [README del proyecto](../README.md) — qué es el producto, cómo correrlo localmente
+2. [Arquitectura](ARCHITECTURE.es.md) — el diagrama y las 6 reglas estrictas
+3. [Glosario](GLOSSARY.es.md) — manténgalo abierto en otra pestaña
+4. [Notas técnicas](technical-notes.md) — profundice
+5. [Instrucciones Copilot](../copilot-instructions.md) — reglas de codificación
+6. [Contribuir](../CONTRIBUTING.md) — fork, rama, PR, CLA
+
+---
+
+## Orden de lectura para una municipalidad
+
+Si es un funcionario municipal o líder de TI evaluando esto:
+
+1. [Para Municipalidades](FOR_MUNICIPALITIES.es.md) — **comience aquí**
+2. [Glosario](GLOSSARY.es.md) — guárdelo a mano
+3. [Despliegue](DEPLOYMENT.es.md) — comparta con su informático
+4. [Alta de Municipio](TENANT_ONBOARDING.es.md) — comparta con su informático
+5. [Manual de Administración](ADMIN_MANUAL.es.md) — distribúyalo al personal que usará el portal
+6. [Guía de Contenido](CONTENT_GUIDE.es.md) — distribúyala a sus traductores y equipo de comunicación
+
+---
+
+## Cómo proponer un cambio
+
+No necesita instalar nada. Desde cualquier documento en GitHub:
+
+1. Haga clic en el **icono de lápiz** arriba a la derecha del archivo.
+2. Edite el texto directamente en su navegador.
+3. Baje, escriba un mensaje breve describiendo el cambio, haga clic en **Propose changes**.
+4. Haga clic en **Create pull request**.
+
+Eso es todo. Un mantenedor revisará y fusionará.
+
+Si una frase no está clara, una traducción es incorrecta, un enlace está roto o falta una sección — abra una Pull Request o [un issue](https://github.com/haitiansintech/HaitiCityPortal/issues/new/choose).
+
+---
+
+## Sobre las traducciones
+
+Cada documento de esta carpeta está disponible en cuatro idiomas: inglés (`.md`), francés (`.fr.md`), criollo haitiano (`.ht.md`), español (`.es.md`). La versión en inglés es la fuente de verdad — cuando cambie un dato en inglés, actualice también las otras tres versiones, o abra un issue indicando qué traducciones necesitan actualizarse.
+
+Las traducciones de este conjunto inicial fueron producidas por colaboradores y se beneficiarán de revisión por hablantes nativos. Si nota una frase forzada o una mala traducción, abra un PR o un issue — las correcciones son muy bienvenidas.
+
+---
+
+[↑ Volver arriba](#haiti-city-portal--documentación) · [README del proyecto](../README.md)

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -1,0 +1,130 @@
+<!--
+Langues : English (README.md) | Français (ce fichier) | Kreyòl (README.ht.md) | Español (README.es.md)
+-->
+
+**Langues :** [English](README.md) · **Français** · [Kreyòl Ayisyen](README.ht.md) · [Español](README.es.md)
+
+[← Retour au README du projet](../README.md)
+
+---
+
+# Haiti City Portal — Documentation
+
+Bienvenue. Cet index est la porte d'entrée de tous les documents du projet. Choisissez le document qui correspond à votre rôle — vous n'avez pas besoin de tout lire.
+
+## Sommaire
+
+- [Commencer ici selon votre rôle](#commencer-ici-selon-votre-rôle)
+- [Tous les documents](#tous-les-documents)
+- [Ordre de lecture pour un nouveau contributeur](#ordre-de-lecture-pour-un-nouveau-contributeur)
+- [Ordre de lecture pour une municipalité](#ordre-de-lecture-pour-une-municipalité)
+- [Comment proposer une modification](#comment-proposer-une-modification)
+- [À propos des traductions](#à-propos-des-traductions)
+
+---
+
+## Commencer ici selon votre rôle
+
+| Vous êtes… | Commencez par |
+|---|---|
+| **Maire, conseiller ou agent municipal** qui évalue le projet pour sa municipalité | [Pour les municipalités](FOR_MUNICIPALITIES.fr.md) |
+| **Développeur** souhaitant contribuer au code | [Architecture](ARCHITECTURE.fr.md) → [Notes techniques](technical-notes.md) → [Contribuer](../CONTRIBUTING.md) |
+| **Administrateur système / informaticien** qui doit déployer le projet | [Déploiement](DEPLOYMENT.fr.md) → [Intégration d'une commune](TENANT_ONBOARDING.fr.md) |
+| **Agent municipal** qui utilisera le panneau d'administration | [Manuel d'administration](ADMIN_MANUAL.fr.md) |
+| **Traducteur ou éditeur de contenu** (sans coder) | [Guide de contenu](CONTENT_GUIDE.fr.md) |
+| **Citoyen** curieux de savoir ce que c'est | [Pour les municipalités](FOR_MUNICIPALITIES.fr.md) (section « Qu'est-ce que c'est ») |
+| **Vous ne comprenez pas un mot** dans un document | [Glossaire](GLOSSARY.fr.md) |
+
+---
+
+## Tous les documents
+
+### Vue d'ensemble en langage clair
+
+| Document | Objet |
+|---|---|
+| [Pour les municipalités](FOR_MUNICIPALITIES.fr.md) | Non technique : ce que c'est, ce qu'il vous faut, ce que ça coûte, qui contacter |
+| [Glossaire](GLOSSARY.fr.md) | Définitions claires de tous les termes techniques et civiques haïtiens utilisés |
+| [Code de conduite](../CODE_OF_CONDUCT.fr.md) | Comportement attendu des contributeurs et des membres de la communauté |
+
+### Exploitation (déployer et faire tourner le portail)
+
+| Document | Objet |
+|---|---|
+| [Déploiement](DEPLOYMENT.fr.md) | Étape par étape : domaine, DNS, hébergement, base de données, variables, premier déploiement |
+| [Intégration d'une commune](TENANT_ONBOARDING.fr.md) | Comment ajouter une nouvelle ville : créer le tenant, configurer le sous-domaine, l'image de marque, les officiels, le premier admin |
+| [Manuel d'administration](ADMIN_MANUAL.fr.md) | Comment le personnel municipal utilise le panneau au quotidien |
+| [Guide de contenu](CONTENT_GUIDE.fr.md) | Traduire ou modifier du contenu via le site GitHub (aucun outil à installer) |
+| [Protection de branche](BRANCH_PROTECTION.md) | Configuration de la protection de la branche `main` pour les administrateurs du dépôt |
+
+### Ingénierie
+
+| Document | Objet |
+|---|---|
+| [Architecture](ARCHITECTURE.fr.md) | Vue d'ensemble en une page avec diagramme |
+| [Notes techniques](technical-notes.md) | Approfondissement : tenants, contenu, authentification, paiements, cartes |
+| [Exigences produit (PRD)](haiti-city-portal-prd.md) | Liste complète des fonctionnalités et des utilisateurs cibles |
+| [État de l'implémentation](v0.1-implementation-plan.md) | Inventaire à cocher de ce qui est fait et ce qui reste |
+| [Décisions d'architecture (ADR)](adr/README.fr.md) | Les « pourquoi » derrière les choix techniques majeurs |
+| [Instructions Copilot](../copilot-instructions.md) | Règles strictes pour les assistants IA et les contributeurs |
+
+### Politique
+
+| Document | Objet |
+|---|---|
+| [Politique de sécurité](../SECURITY.md) | Comment signaler une vulnérabilité et le modèle de sécurité du projet |
+| [Contribuer](../CONTRIBUTING.md) | Comment forker, contribuer au code et traduire |
+| [Licence](../LICENSE.md) | Business Source License 1.1 (devient Apache 2.0 le 31 décembre 2028) |
+
+---
+
+## Ordre de lecture pour un nouveau contributeur
+
+Pour écrire du code dans ce projet :
+
+1. [README du projet](../README.md) — ce qu'est le produit et comment le lancer localement
+2. [Architecture](ARCHITECTURE.fr.md) — le diagramme et les 6 règles strictes
+3. [Glossaire](GLOSSARY.fr.md) — gardez-le ouvert dans un autre onglet
+4. [Notes techniques](technical-notes.md) — approfondissement
+5. [Instructions Copilot](../copilot-instructions.md) — règles de codage
+6. [Contribuer](../CONTRIBUTING.md) — fork, branche, PR, CLA
+
+---
+
+## Ordre de lecture pour une municipalité
+
+Si vous êtes un élu ou un responsable informatique évaluant le projet :
+
+1. [Pour les municipalités](FOR_MUNICIPALITIES.fr.md) — **commencez ici**
+2. [Glossaire](GLOSSARY.fr.md) — gardez-le sous la main
+3. [Déploiement](DEPLOYMENT.fr.md) — partagez avec votre informaticien
+4. [Intégration d'une commune](TENANT_ONBOARDING.fr.md) — partagez avec votre informaticien
+5. [Manuel d'administration](ADMIN_MANUAL.fr.md) — distribuez au personnel qui utilisera le portail
+6. [Guide de contenu](CONTENT_GUIDE.fr.md) — distribuez à vos traducteurs et à votre équipe communication
+
+---
+
+## Comment proposer une modification
+
+Aucun outil à installer. Depuis n'importe quel document sur GitHub :
+
+1. Cliquez sur l'**icône crayon** en haut à droite du fichier.
+2. Modifiez le texte directement dans votre navigateur.
+3. Descendez, décrivez brièvement votre changement, cliquez **Propose changes**.
+4. Cliquez **Create pull request**.
+
+C'est tout. Un mainteneur examinera et fusionnera.
+
+Si une phrase n'est pas claire, qu'une traduction est fausse, qu'un lien est cassé, ou qu'une section manque — ouvrez une Pull Request ou [créez une issue](https://github.com/haitiansintech/HaitiCityPortal/issues/new/choose).
+
+---
+
+## À propos des traductions
+
+Chaque document est fourni en quatre langues : anglais (`.md`), français (`.fr.md`), créole haïtien (`.ht.md`), espagnol (`.es.md`). La version anglaise fait foi — quand vous modifiez un fait en anglais, mettez aussi à jour les trois autres versions, ou ouvrez une issue précisant les traductions à actualiser.
+
+Les traductions initiales ont été produites par des contributeurs et bénéficieront d'une relecture par des locuteurs natifs. Toute correction est la bienvenue via Pull Request ou issue.
+
+---
+
+[↑ Retour en haut](#haiti-city-portal--documentation) · [README du projet](../README.md)

--- a/docs/README.ht.md
+++ b/docs/README.ht.md
@@ -1,0 +1,130 @@
+<!--
+Lang yo: English (README.md) | Français (README.fr.md) | Kreyòl (fichye sa a) | Español (README.es.md)
+-->
+
+**Lang yo:** [English](README.md) · [Français](README.fr.md) · **Kreyòl Ayisyen** · [Español](README.es.md)
+
+[← Retounen nan README pwojè a](../README.md)
+
+---
+
+# Haiti City Portal — Dokimantasyon
+
+Byenveni. Endèks sa a se pòt antre pou tout dokiman pwojè a. Chwazi dokiman ki matche ak wòl ou — ou pa oblije li tout bagay.
+
+## Tablo Kontni
+
+- [Kòmanse isit la dapre wòl ou](#kòmanse-isit-la-dapre-wòl-ou)
+- [Tout dokiman yo](#tout-dokiman-yo)
+- [Lòd lekti pou yon nouvo kontribitè](#lòd-lekti-pou-yon-nouvo-kontribitè)
+- [Lòd lekti pou yon minisipalite](#lòd-lekti-pou-yon-minisipalite)
+- [Kijan pou pwopoze yon chanjman](#kijan-pou-pwopoze-yon-chanjman)
+- [Sou tradiksyon yo](#sou-tradiksyon-yo)
+
+---
+
+## Kòmanse isit la dapre wòl ou
+
+| Si w se… | Kòmanse ak |
+|---|---|
+| Yon **majistra, konseye, oswa anplwaye lameri** k ap evalye sa pou minisipalite ou | [Pou Minisipalite yo](FOR_MUNICIPALITIES.ht.md) |
+| Yon **devlopè** ki vle kontribye nan kòd la | [Achitekti](ARCHITECTURE.ht.md) → [Nòt Teknik](technical-notes.md) → [Kontribye](../CONTRIBUTING.md) |
+| Yon **administratè sistèm / enfòmatisyen** ki gen pou deplwaye sa | [Deplwaman](DEPLOYMENT.ht.md) → [Mete yon Vil Anplas](TENANT_ONBOARDING.ht.md) |
+| Yon **anplwaye lameri** ki pral itilize panèl administrasyon | [Manyèl Administrasyon](ADMIN_MANUAL.ht.md) |
+| Yon **tradiktè oswa editè kontni** (san kodaj) | [Gid Kontni](CONTENT_GUIDE.ht.md) |
+| Yon **sitwayen** ki kirye pou konnen kisa pwojè a ye | [Pou Minisipalite yo](FOR_MUNICIPALITIES.ht.md) (seksyon « Kisa li ye ») |
+| Ou **pa konprann yon mo** nan yon dokiman | [Glosè](GLOSSARY.ht.md) |
+
+---
+
+## Tout dokiman yo
+
+### Apèsi an lang senp
+
+| Dokiman | Objektif |
+|---|---|
+| [Pou Minisipalite yo](FOR_MUNICIPALITIES.ht.md) | San tèm teknik: sa li ye, sa w bezwen, konbyen sa koute, kilès pou kontakte |
+| [Glosè](GLOSSARY.ht.md) | Definisyon klè pou chak tèm teknik ak sivik ayisyen yo itilize nan dokiman yo |
+| [Kòd Kondwit](../CODE_OF_CONDUCT.ht.md) | Konpòtman ki atann pou kontribitè ak manm kominote a |
+
+### Operasyon (deplwaye epi fè pòtal la mache)
+
+| Dokiman | Objektif |
+|---|---|
+| [Deplwaman](DEPLOYMENT.ht.md) | Etap pa etap: domèn, DNS, ebèjman, baz done, varyab, premye deplwaman |
+| [Mete yon Vil Anplas](TENANT_ONBOARDING.ht.md) | Kijan pou ajoute yon nouvo vil: kreye tenant la, konfigire soudomèn, mak, ofisyèl, premye admin |
+| [Manyèl Administrasyon](ADMIN_MANUAL.ht.md) | Kijan staf minisipal la itilize panèl la chak jou |
+| [Gid Kontni](CONTENT_GUIDE.ht.md) | Tradwi oswa modifye kontni atravè sit GitHub (san Git, san kodaj) |
+| [Pwoteksyon Branch](BRANCH_PROTECTION.md) | Konfigirasyon pwoteksyon branch `main` pou administratè depo a |
+
+### Jeni
+
+| Dokiman | Objektif |
+|---|---|
+| [Achitekti](ARCHITECTURE.ht.md) | Apèsi achitekti sou yon paj ak yon dyagram |
+| [Nòt Teknik](technical-notes.md) | Detay sou tenants, kontni, otantifikasyon, peyman, kat |
+| [Egzijans Pwodwi (PRD)](haiti-city-portal-prd.md) | Lis konplè karakteristik ak itilizatè sib |
+| [Estati Aplikasyon an](v0.1-implementation-plan.md) | Lis tout sa ki fèt ak sa ki rete |
+| [Dosye Desizyon Achitekti (ADR)](adr/README.ht.md) | « Poukisa » dèyè chwa teknik enpòtan yo |
+| [Enstriksyon Copilot](../copilot-instructions.md) | Règ strik pou asistan IA ak kontribitè |
+
+### Politik
+
+| Dokiman | Objektif |
+|---|---|
+| [Politik Sekirite](../SECURITY.md) | Kijan pou rapòte yon vilnerabilite ak modèl sekirite pwojè a |
+| [Kontribye](../CONTRIBUTING.md) | Kijan pou forke, kontribye nan kòd, ak tradwi |
+| [Lisans](../LICENSE.md) | Business Source License 1.1 (vin Apache 2.0 nan 31 desanm 2028) |
+
+---
+
+## Lòd lekti pou yon nouvo kontribitè
+
+Si w vle ekri kòd nan pwojè sa a, li nan lòd sa a:
+
+1. [README pwojè a](../README.md) — kisa pwodwi a ye, kijan pou fè l mache lokalman
+2. [Achitekti](ARCHITECTURE.ht.md) — dyagram ak 6 règ strik yo
+3. [Glosè](GLOSSARY.ht.md) — kenbe l louvri nan yon lòt onglè
+4. [Nòt Teknik](technical-notes.md) — ale fon
+5. [Enstriksyon Copilot](../copilot-instructions.md) — règ kodaj
+6. [Kontribye](../CONTRIBUTING.md) — fork, branch, PR, CLA
+
+---
+
+## Lòd lekti pou yon minisipalite
+
+Si w se yon ofisyèl vil oswa lidè IT k ap evalye sa pou minisipalite ou:
+
+1. [Pou Minisipalite yo](FOR_MUNICIPALITIES.ht.md) — **kòmanse isit la**
+2. [Glosè](GLOSSARY.ht.md) — make l pou nenpòt mo etranj
+3. [Deplwaman](DEPLOYMENT.ht.md) — pataje l ak enfòmatisyen ou
+4. [Mete yon Vil Anplas](TENANT_ONBOARDING.ht.md) — pataje l ak enfòmatisyen ou
+5. [Manyèl Administrasyon](ADMIN_MANUAL.ht.md) — distribiye l bay anplwaye ki pral itilize pòtal la
+6. [Gid Kontni](CONTENT_GUIDE.ht.md) — distribiye l bay tradiktè ou ak ekip kominikasyon
+
+---
+
+## Kijan pou pwopoze yon chanjman
+
+Ou pa bezwen enstale anyen. Soti nan nenpòt dokiman sou GitHub:
+
+1. Klike sou **ikòn kreyon** anwo adwat fichye a.
+2. Modifye tèks la dirèkteman nan navigatè ou.
+3. Desann anba, ekri yon ti mesaj k ap dekri chanjman ou, klike **Propose changes**.
+4. Klike **Create pull request**.
+
+Sa a se tout sa. Yon mainteneur ap revize epi fizyone.
+
+Si yon fraz pa klè, yon tradiksyon mal fèt, yon lyen kase, oswa yon seksyon manke — louvri yon Pull Request oswa [yon issue](https://github.com/haitiansintech/HaitiCityPortal/issues/new/choose).
+
+---
+
+## Sou tradiksyon yo
+
+Chak dokiman nan dosye sa a disponib nan kat lang: anglè (`.md`), franse (`.fr.md`), kreyòl ayisyen (`.ht.md`), espanyòl (`.es.md`). Vèsyon anglè a se sous laverite — lè w chanje yon enfòmasyon an anglè, tanpri mete twa lòt vèsyon yo ajou tou, oswa louvri yon issue ki di ki tradiksyon ki bezwen mizajou.
+
+Tradiksyon premye seri dokiman sa yo te fèt pa kontribitè e yo ka bezwen revizyon pa moun ki natif. Si w wè yon fraz ki dwòl oswa yon move tradiksyon, tanpri louvri yon PR oswa yon issue — koreksyon yo akeyi anpil.
+
+---
+
+[↑ Retounen anwo](#haiti-city-portal--dokimantasyon) · [README pwojè a](../README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,130 @@
+<!--
+Languages: English (this file) | Français (README.fr.md) | Kreyòl (README.ht.md) | Español (README.es.md)
+-->
+
+**Languages:** **English** · [Français](README.fr.md) · [Kreyòl Ayisyen](README.ht.md) · [Español](README.es.md)
+
+[← Back to project README](../README.md)
+
+---
+
+# Haiti City Portal — Documentation
+
+Welcome. This index is the front door to every document in the project. Pick the doc that matches your role — you don't have to read everything.
+
+## Table of Contents
+
+- [Start here by audience](#start-here-by-audience)
+- [All documents](#all-documents)
+- [Reading order for a new contributor](#reading-order-for-a-new-contributor)
+- [Reading order for a municipality](#reading-order-for-a-municipality)
+- [How to suggest a doc change](#how-to-suggest-a-doc-change)
+- [About translations](#about-translations)
+
+---
+
+## Start here by audience
+
+| You are… | Start with |
+|---|---|
+| A **mayor, councillor, or city staff member** evaluating this for your municipality | [For Municipalities](FOR_MUNICIPALITIES.md) |
+| A **developer** who wants to contribute code | [Architecture](ARCHITECTURE.md) → [Technical Notes](technical-notes.md) → [Contributing](../CONTRIBUTING.md) |
+| A **system administrator / IT person** who has to deploy this | [Deployment](DEPLOYMENT.md) → [Tenant Onboarding](TENANT_ONBOARDING.md) |
+| A **municipal staff member** who will use the admin panel | [Admin Manual](ADMIN_MANUAL.md) |
+| A **translator or content editor** (no coding) | [Content Guide](CONTENT_GUIDE.md) |
+| A **citizen** curious about what the project is | [For Municipalities](FOR_MUNICIPALITIES.md) (the "What it is" section) |
+| **Confused by a word** in any document | [Glossary](GLOSSARY.md) |
+
+---
+
+## All documents
+
+### Plain-language overviews
+
+| Document | Purpose |
+|---|---|
+| [For Municipalities](FOR_MUNICIPALITIES.md) | Non-technical: what this is, what you need, what it costs, who to contact |
+| [Glossary](GLOSSARY.md) | Plain definitions of every technical and Haitian-civic term used in the docs |
+| [Code of Conduct](../CODE_OF_CONDUCT.md) | Expected behaviour for contributors and community members |
+
+### Operations (deploy and run the portal)
+
+| Document | Purpose |
+|---|---|
+| [Deployment](DEPLOYMENT.md) | Step-by-step: domain, DNS, hosting, database, environment variables, first deploy |
+| [Tenant Onboarding](TENANT_ONBOARDING.md) | How to add a new city: create the tenant, configure subdomain, brand, seed officials, create the first admin |
+| [Admin Manual](ADMIN_MANUAL.md) | How municipal staff use the admin panel day-to-day |
+| [Content Guide](CONTENT_GUIDE.md) | How to translate or edit content via the GitHub website (no Git or coding required) |
+| [Branch Protection](BRANCH_PROTECTION.md) | GitHub branch protection setup for repository administrators |
+
+### Engineering
+
+| Document | Purpose |
+|---|---|
+| [Architecture](ARCHITECTURE.md) | One-page architecture overview with diagram |
+| [Technical Notes](technical-notes.md) | Deep-dive on tenants, content, auth, payments, maps |
+| [Product Requirements (PRD)](haiti-city-portal-prd.md) | Complete feature list and target users |
+| [Implementation Status](v0.1-implementation-plan.md) | Checkbox audit of what's built and what remains |
+| [Architecture Decision Records (ADRs)](adr/README.md) | The "why" behind major technical choices |
+| [Copilot Instructions](../copilot-instructions.md) | Hard rules for AI coding assistants and contributors |
+
+### Policy
+
+| Document | Purpose |
+|---|---|
+| [Security Policy](../SECURITY.md) | How to report a vulnerability and the project's security model |
+| [Contributing](../CONTRIBUTING.md) | How to fork, contribute code, and translate |
+| [License](../LICENSE.md) | Business Source License 1.1 (converts to Apache 2.0 on Dec 31, 2028) |
+
+---
+
+## Reading order for a new contributor
+
+If you want to write code for this project, read in this order:
+
+1. [Project README](../README.md) — what the product is, how to run it locally
+2. [Architecture](ARCHITECTURE.md) — the diagram and the 6 hard rules
+3. [Glossary](GLOSSARY.md) — keep this open in another tab
+4. [Technical Notes](technical-notes.md) — go deep
+5. [Copilot Instructions](../copilot-instructions.md) — coding rules
+6. [Contributing](../CONTRIBUTING.md) — fork, branch, PR, CLA
+
+---
+
+## Reading order for a municipality
+
+If you are a city official or IT lead evaluating this for your municipality:
+
+1. [For Municipalities](FOR_MUNICIPALITIES.md) — **start here**
+2. [Glossary](GLOSSARY.md) — bookmark for any unfamiliar word
+3. [Deployment](DEPLOYMENT.md) — share with your IT person
+4. [Tenant Onboarding](TENANT_ONBOARDING.md) — share with your IT person
+5. [Admin Manual](ADMIN_MANUAL.md) — distribute to staff who will use the portal
+6. [Content Guide](CONTENT_GUIDE.md) — distribute to your translators and communications team
+
+---
+
+## How to suggest a doc change
+
+You don't need to install anything. From any document on GitHub:
+
+1. Click the **pencil icon** in the upper right of the file view.
+2. Edit the text in your browser.
+3. Scroll down, write a short message describing your change, click **Propose changes**.
+4. Click **Create pull request**.
+
+That's it. A maintainer will review and merge.
+
+If a phrase is unclear, a translation is wrong, a link is broken, or a section is missing — please open a Pull Request or [file an issue](https://github.com/haitiansintech/HaitiCityPortal/issues/new/choose).
+
+---
+
+## About translations
+
+Every document in this folder is provided in four languages: English (`.md`), French (`.fr.md`), Haitian Creole (`.ht.md`), and Spanish (`.es.md`). The English version is the source of truth — when you change a fact in English, please update the other three versions as well, or open an issue noting which translations need updating.
+
+Translations of this initial documentation set were produced by contributors and may benefit from native-speaker review. If you spot an awkward phrase or a mistranslation, please open a PR or an issue — corrections are very welcome.
+
+---
+
+[↑ Back to top](#haiti-city-portal--documentation) · [Project README](../README.md)

--- a/docs/TENANT_ONBOARDING.es.md
+++ b/docs/TENANT_ONBOARDING.es.md
@@ -1,0 +1,266 @@
+<!--
+Idiomas: English (TENANT_ONBOARDING.md) | Français (TENANT_ONBOARDING.fr.md) | Kreyòl (TENANT_ONBOARDING.ht.md) | Español (este archivo)
+-->
+
+**Idiomas:** [English](TENANT_ONBOARDING.md) · [Français](TENANT_ONBOARDING.fr.md) · [Kreyòl Ayisyen](TENANT_ONBOARDING.ht.md) · **Español**
+
+[← Índice de documentación](README.es.md) · [README del proyecto](../README.md) · [Glosario](GLOSSARY.es.md)
+
+---
+
+# Alta de Municipio (tenant onboarding)
+
+Cómo agregar una nueva comuna (un "tenant") a un despliegue de Haiti City Portal en marcha. Este documento continúa donde termina [Despliegue](DEPLOYMENT.es.md).
+
+## Índice
+
+- [¿Qué es un tenant?](#qué-es-un-tenant)
+- [Prerrequisitos](#prerrequisitos)
+- [Lista de chequeo](#lista-de-chequeo)
+- [Paso 1 — Elegir un subdominio](#paso-1--elegir-un-subdominio)
+- [Paso 2 — Crear la fila tenant](#paso-2--crear-la-fila-tenant)
+- [Paso 3 — Verificar que el subdominio responde](#paso-3--verificar-que-el-subdominio-responde)
+- [Paso 4 — Crear el primer usuario admin](#paso-4--crear-el-primer-usuario-admin)
+- [Paso 5 — Cargar oficiales y secciones comunales](#paso-5--cargar-oficiales-y-secciones-comunales)
+- [Paso 6 — Cargar instalaciones](#paso-6--cargar-instalaciones)
+- [Paso 7 — Cargar servicios y noticias](#paso-7--cargar-servicios-y-noticias)
+- [Paso 8 — Personalizar el tenant](#paso-8--personalizar-el-tenant)
+- [Paso 9 — Capacitar al personal y lanzar](#paso-9--capacitar-al-personal-y-lanzar)
+- [Renombrar o eliminar un tenant](#renombrar-o-eliminar-un-tenant)
+- [Errores frecuentes](#errores-frecuentes)
+
+---
+
+## ¿Qué es un tenant?
+
+Un **tenant** es una comuna. Cada registro en la base (oficiales, solicitudes, pagos, noticias) pertenece a un solo tenant. El portal sirve a cualquier número de tenants desde una sola aplicación — cada uno se accede por su subdominio.
+
+Una fila en la tabla `tenants` es la fuente de verdad. Su columna `subdomain` controla el ruteo. Si `tenants.subdomain = "jacmel"`, entonces `https://jacmel.portal.ht` es el portal de esa comuna.
+
+Más en [Arquitectura](ARCHITECTURE.es.md).
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Prerrequisitos
+
+Antes de agregar un tenant nuevo:
+
+- Despliegue de producción funcionando ([Despliegue](DEPLOYMENT.es.md)).
+- DNS comodín configurado (`*.portal.ht`).
+- Dominio comodín agregado en Vercel (**Settings → Domains**).
+- Acceso a la base (`DATABASE_URL`).
+
+Identifique el **sponsor del tenant** (alcalde o jefe de gabinete) y el **líder del tenant** (personal a cargo del contenido y la admin).
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Lista de chequeo
+
+Para cada nueva comuna:
+
+- [ ] Subdominio elegido
+- [ ] Fila tenant creada
+- [ ] Subdominio responde con HTTPS
+- [ ] Primer admin creado
+- [ ] Secciones comunales cargadas
+- [ ] Oficiales cargados
+- [ ] Instalaciones agregadas (o importadas)
+- [ ] Servicios descritos en MDX (o fallback inglés al inicio)
+- [ ] Al menos una noticia publicada
+- [ ] Logo, colores, foto del alcalde configurados
+- [ ] Al menos dos miembros del personal capacitados
+- [ ] Lanzamiento restringido
+- [ ] Lanzamiento público
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Paso 1 — Elegir un subdominio
+
+Identificador corto, memorable, en minúsculas, sin espacios ni caracteres especiales.
+
+| Comuna | Subdominio sugerido |
+|---|---|
+| Jacmel | `jacmel` |
+| Cap-Haïtien | `cap` o `capha` |
+| Port-au-Prince | `pap` |
+| Pétion-Ville | `petionville` |
+| Les Cayes | `cayes` |
+| Croix-des-Bouquets | `croix` |
+
+URL final: `https://{subdomain}.portal.ht`.
+
+**Palabras reservadas a evitar:** `www`, `admin`, `api`, `static`, `assets`, `cdn`, `mail`, `email`, `app`, `staging`, `dev`, `test`, `localhost`, `demo`.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Paso 2 — Crear la fila tenant
+
+Dos métodos.
+
+### Opción A — Script seed (recomendado para el primer tenant)
+
+Vea [Despliegue, paso 6.2](DEPLOYMENT.es.md#paso-6--esquema-inicial-y-seed). Crea fila tenant y superadmin de una vez.
+
+### Opción B — Drizzle Studio (para comunas siguientes)
+
+```bash
+npm run db:studio
+```
+
+1. Tabla `tenants` → **+ Add Record**.
+2. `name`: `Ville du Cap-Haïtien`. `subdomain`: `cap`.
+3. Guardar. Anote el `id` (UUID).
+
+### Opción C — SQL directo
+
+```sql
+INSERT INTO tenants (name, subdomain)
+VALUES ('Ville du Cap-Haïtien', 'cap')
+RETURNING id;
+```
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Paso 3 — Verificar que el subdominio responde
+
+Abra `https://cap.portal.ht`. Debe ver la home con el nombre de la comuna.
+
+Si "DB unavailable":
+- CNAME comodín DNS.
+- `*.portal.ht` en Vercel **Settings → Domains**.
+- `subdomain` coincide con la URL (sensible a mayúsculas, minúsculas).
+- SSL provisionado (hasta 10 minutos la primera vez).
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Paso 4 — Crear el primer usuario admin
+
+### Opción A — Drizzle Studio
+
+1. Tabla `users` → **+ Add Record**.
+2. `tenant_id`: UUID del paso 2. `email`: `admin@cap.portal.ht`.
+3. `password_hash`: hash bcrypt **no la contraseña en texto**:
+   ```bash
+   node -e "console.log(require('bcryptjs').hashSync('SU_CONTRASEÑA', 10))"
+   ```
+4. `role`: `superadmin`. `name`: `Admin Cap-Haïtien`.
+5. Guardar.
+
+### Opción B — SQL
+
+```sql
+INSERT INTO users (tenant_id, email, password_hash, role, name)
+VALUES ('<UUID>', 'admin@cap.portal.ht', '$2a$10$...', 'superadmin', 'Admin Cap-Haïtien');
+```
+
+Pruebe en `https://cap.portal.ht/login`.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Paso 5 — Cargar oficiales y secciones comunales
+
+### 5.1 Secciones comunales
+
+Para cada sección, fila en `communal_sections`: `tenant_id`, `name` ("1ère Section Bas Limbé"), `code` (`cap-1`).
+
+### 5.2 Oficiales
+
+Para cada electo, fila en `officials`: `tenant_id`, `name`, `role` (`casec`/`asec`/`mayor`/`town_delegate`), `communal_section_id`, `whatsapp`, `vwa_profile_url`, `photo_url`.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Paso 6 — Cargar instalaciones
+
+Filas en `facilities`: `tenant_id`, `name`, `category` (hospital/school/police/church/market/other), `latitude`, `longitude`, `address`, `phone`.
+
+Tip: residentes pueden sugerir correcciones; llegan a `facility_suggestions`.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Paso 7 — Cargar servicios y noticias
+
+Servicios y noticias son **archivos de contenido**, no filas BD. Vea [Guía de Contenido](CONTENT_GUIDE.es.md). Los ocho servicios por defecto bastan para la mayoría al lanzamiento.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Paso 8 — Personalizar el tenant
+
+Hoy personalizable por tenant:
+- `name` en la navbar.
+- `subdomain`.
+- Fotos vía `officials.photo_url`.
+
+Logo y colores propios en hoja de ruta. Mientras tanto: ponga sus visuales en `public/tenants/{subdomain}/`.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Paso 9 — Capacitar al personal y lanzar
+
+Distribuya [Manual de Administración](ADMIN_MANUAL.es.md). Sesión de 1–2 h: login, solicitudes, verificación de pago, noticia, alerta, traspaso. Luego lanzamiento restringido y público.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Renombrar o eliminar un tenant
+
+### Renombrar
+
+`name` puede cambiar. `subdomain` debe permanecer estable. Si debe cambiarlo: cree el nuevo, redirija el antiguo, comunique 90 días.
+
+### Eliminar
+
+Respalde primero. Borre filas dependientes antes de `tenants`:
+
+```sql
+DELETE FROM payment_records WHERE tenant_id = '<UUID>';
+DELETE FROM service_requests WHERE tenant_id = '<UUID>';
+DELETE FROM facilities WHERE tenant_id = '<UUID>';
+-- ... para cada tabla de entidad ...
+DELETE FROM tenants WHERE id = '<UUID>';
+```
+
+Mejor: archivar en lugar de borrar.
+
+[↑ Volver arriba](#índice)
+
+---
+
+## Errores frecuentes
+
+| Error | Síntoma | Solución |
+|---|---|---|
+| `*.portal.ht` no agregado a Vercel | 404 | Settings → Domains |
+| Subdominio en mayúsculas | No encuentra tenant | Solo minúsculas |
+| Contraseña en texto plano en `password_hash` | Login siempre falla | Generar hash bcrypt |
+| `tenant_id` olvidado | Fila invisible | Actualizar fila |
+| Dos tenants con mismo `subdomain` | Ruteo indefinido | Restricción de unicidad |
+| Palabra reservada como subdominio | Conflicto | Elegir otra |
+
+[↑ Volver arriba](#índice)
+
+---
+
+[← Índice de documentación](README.es.md) · [Despliegue](DEPLOYMENT.es.md) · [Manual de Administración →](ADMIN_MANUAL.es.md)

--- a/docs/TENANT_ONBOARDING.fr.md
+++ b/docs/TENANT_ONBOARDING.fr.md
@@ -1,0 +1,267 @@
+<!--
+Langues : English (TENANT_ONBOARDING.md) | Français (ce fichier) | Kreyòl (TENANT_ONBOARDING.ht.md) | Español (TENANT_ONBOARDING.es.md)
+-->
+
+**Langues :** [English](TENANT_ONBOARDING.md) · **Français** · [Kreyòl Ayisyen](TENANT_ONBOARDING.ht.md) · [Español](TENANT_ONBOARDING.es.md)
+
+[← Index de la documentation](README.fr.md) · [README du projet](../README.md) · [Glossaire](GLOSSARY.fr.md)
+
+---
+
+# Intégration d'une commune (tenant onboarding)
+
+Comment ajouter une nouvelle commune (un « tenant ») à un déploiement Haiti City Portal en cours. Ce document prend la suite de [Déploiement](DEPLOYMENT.fr.md).
+
+## Sommaire
+
+- [Qu'est-ce qu'un tenant ?](#quest-ce-quun-tenant-)
+- [Prérequis](#prérequis)
+- [Liste de contrôle](#liste-de-contrôle)
+- [Étape 1 — Choisir un sous-domaine](#étape-1--choisir-un-sous-domaine)
+- [Étape 2 — Créer la ligne tenant](#étape-2--créer-la-ligne-tenant)
+- [Étape 3 — Vérifier que le sous-domaine répond](#étape-3--vérifier-que-le-sous-domaine-répond)
+- [Étape 4 — Créer le premier utilisateur admin](#étape-4--créer-le-premier-utilisateur-admin)
+- [Étape 5 — Ajouter élus et sections communales](#étape-5--ajouter-élus-et-sections-communales)
+- [Étape 6 — Ajouter les installations](#étape-6--ajouter-les-installations)
+- [Étape 7 — Ajouter services et actualités](#étape-7--ajouter-services-et-actualités)
+- [Étape 8 — Personnaliser la commune](#étape-8--personnaliser-la-commune)
+- [Étape 9 — Former le personnel et lancer](#étape-9--former-le-personnel-et-lancer)
+- [Renommer ou supprimer une commune](#renommer-ou-supprimer-une-commune)
+- [Erreurs fréquentes](#erreurs-fréquentes)
+
+---
+
+## Qu'est-ce qu'un tenant ?
+
+Un **tenant** est une commune. Chaque enregistrement de la base (élus, demandes, paiements, actualités) appartient à un seul tenant. Le portail dessert un nombre quelconque de tenants depuis une seule application — chacun via son propre sous-domaine.
+
+Une ligne dans la table `tenants` fait foi. Sa colonne `subdomain` pilote le routage. Si `tenants.subdomain = "jacmel"`, alors `https://jacmel.portal.ht` est le portail de cette commune.
+
+Architecture détaillée : [Architecture](ARCHITECTURE.fr.md).
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Prérequis
+
+Avant d'ajouter un nouveau tenant :
+
+- Déploiement de production fonctionnel ([Déploiement](DEPLOYMENT.fr.md)).
+- DNS wildcard configuré (`*.portal.ht`).
+- Domaine wildcard ajouté dans Vercel (**Settings → Domains**).
+- Accès à la base (`DATABASE_URL`).
+
+Identifiez le **sponsor du tenant** (maire ou chef de cabinet) et le **référent tenant** (l'agent en charge du contenu et de l'admin).
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Liste de contrôle
+
+À cocher pour chaque nouvelle commune :
+
+- [ ] Sous-domaine choisi
+- [ ] Ligne tenant créée
+- [ ] Sous-domaine répond en HTTPS
+- [ ] Premier admin créé
+- [ ] Sections communales saisies
+- [ ] Élus saisis
+- [ ] Installations ajoutées (ou importées)
+- [ ] Services décrits en MDX (ou repli anglais au début)
+- [ ] Au moins un article d'actualité publié
+- [ ] Logo, couleurs, photo du maire configurés
+- [ ] Au moins deux agents formés
+- [ ] Lancement restreint
+- [ ] Lancement public
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Étape 1 — Choisir un sous-domaine
+
+Identifiant court, mémorable, en minuscules, sans espace ni caractère spécial.
+
+| Commune | Sous-domaine suggéré |
+|---|---|
+| Jacmel | `jacmel` |
+| Cap-Haïtien | `cap` ou `capha` |
+| Port-au-Prince | `pap` |
+| Pétion-Ville | `petionville` |
+| Les Cayes | `cayes` |
+| Croix-des-Bouquets | `croix` |
+
+URL finale : `https://{subdomain}.portal.ht`.
+
+**Mots réservés à éviter :** `www`, `admin`, `api`, `static`, `assets`, `cdn`, `mail`, `email`, `app`, `staging`, `dev`, `test`, `localhost`, `demo`.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Étape 2 — Créer la ligne tenant
+
+Deux méthodes.
+
+### Option A — Script de seed (recommandé pour le tout premier tenant)
+
+Voir [Déploiement, étape 6.2](DEPLOYMENT.fr.md#étape-6--schéma-initial-et-seed). Le script crée à la fois la ligne tenant et un superadmin.
+
+### Option B — Drizzle Studio (pour les communes suivantes)
+
+```bash
+npm run db:studio
+```
+
+1. Ouvrez la table `tenants`.
+2. **+ Add Record**.
+3. `name`: `Ville du Cap-Haïtien`. `subdomain`: `cap`.
+4. Sauver. Notez l'`id` (UUID) généré.
+
+### Option C — SQL direct
+
+```sql
+INSERT INTO tenants (name, subdomain)
+VALUES ('Ville du Cap-Haïtien', 'cap')
+RETURNING id;
+```
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Étape 3 — Vérifier que le sous-domaine répond
+
+Ouvrez `https://cap.portal.ht`. La page d'accueil doit s'afficher avec le nom de la commune.
+
+Si « DB unavailable » :
+- CNAME wildcard DNS.
+- `*.portal.ht` dans Vercel **Settings → Domains**.
+- `subdomain` correspond à l'URL (sensible à la casse, minuscules).
+- SSL provisionné (jusqu'à 10 minutes la première fois).
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Étape 4 — Créer le premier utilisateur admin
+
+### Option A — Drizzle Studio
+
+1. Table `users` → **+ Add Record**.
+2. `tenant_id`: UUID de l'étape 2. `email`: `admin@cap.portal.ht`.
+3. `password_hash`: hash bcrypt **et non le mot de passe en clair** :
+   ```bash
+   node -e "console.log(require('bcryptjs').hashSync('VOTRE_MOT_DE_PASSE', 10))"
+   ```
+4. `role`: `superadmin`. `name`: `Admin Cap-Haïtien`.
+5. Sauver.
+
+### Option B — SQL
+
+```sql
+INSERT INTO users (tenant_id, email, password_hash, role, name)
+VALUES ('<UUID>', 'admin@cap.portal.ht', '$2a$10$...', 'superadmin', 'Admin Cap-Haïtien');
+```
+
+Testez sur `https://cap.portal.ht/login`.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Étape 5 — Ajouter élus et sections communales
+
+### 5.1 Sections communales
+
+Pour chaque section, ligne dans `communal_sections` : `tenant_id`, `name` (« 1ère Section Bas Limbé »), `code` (`cap-1`).
+
+### 5.2 Élus
+
+Pour chaque élu, ligne dans `officials` : `tenant_id`, `name`, `role` (`casec`/`asec`/`mayor`/`town_delegate`), `communal_section_id`, `whatsapp`, `vwa_profile_url`, `photo_url`.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Étape 6 — Ajouter les installations
+
+Lignes dans `facilities` : `tenant_id`, `name`, `category` (hospital/school/police/church/market/other), `latitude`, `longitude`, `address`, `phone`.
+
+Astuce : les résidents peuvent suggérer des corrections ; elles arrivent dans `facility_suggestions`.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Étape 7 — Ajouter services et actualités
+
+Services et actualités sont des **fichiers de contenu**, pas des lignes BD. Voir [Guide de contenu](CONTENT_GUIDE.fr.md). Les huit services par défaut suffisent à la plupart des communes au lancement.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Étape 8 — Personnaliser la commune
+
+Aujourd'hui personnalisable par tenant :
+- `name` dans la navbar.
+- `subdomain`.
+- Photos via `officials.photo_url`.
+
+Logo personnalisé et couleurs sur la feuille de route. En attendant : déposez vos visuels dans `public/tenants/{subdomain}/`.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Étape 9 — Former le personnel et lancer
+
+Distribuez [Manuel d'administration](ADMIN_MANUAL.fr.md). Session de 1–2 h : connexion, demandes, vérification de paiement, actualité, alerte, passation. Puis lancement restreint puis public.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Renommer ou supprimer une commune
+
+### Renommer
+
+`name` peut changer. `subdomain` doit rester stable. Si vous devez le changer : créez le nouveau, redirigez l'ancien, communiquez 90 jours.
+
+### Supprimer
+
+Sauvegardez d'abord. Supprimez les lignes dépendantes avant `tenants` :
+
+```sql
+DELETE FROM payment_records WHERE tenant_id = '<UUID>';
+DELETE FROM service_requests WHERE tenant_id = '<UUID>';
+DELETE FROM facilities WHERE tenant_id = '<UUID>';
+-- ... pour chaque table d'entité ...
+DELETE FROM tenants WHERE id = '<UUID>';
+```
+
+Préférez archiver plutôt que supprimer.
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+## Erreurs fréquentes
+
+| Erreur | Symptôme | Correction |
+|---|---|---|
+| `*.portal.ht` non ajouté à Vercel | 404 | Settings → Domains |
+| Sous-domaine en majuscules | Tenant introuvable | Minuscules uniquement |
+| Mot de passe en clair dans `password_hash` | Login échoue toujours | Générer un hash bcrypt |
+| `tenant_id` oublié | Ligne invisible | Mettre à jour la ligne |
+| Deux tenants même `subdomain` | Routage indéfini | Contrainte d'unicité |
+| Mot réservé en subdomain | Conflit | Choisir un autre nom |
+
+[↑ Retour en haut](#sommaire)
+
+---
+
+[← Index de la documentation](README.fr.md) · [Déploiement](DEPLOYMENT.fr.md) · [Manuel d'administration →](ADMIN_MANUAL.fr.md)

--- a/docs/TENANT_ONBOARDING.ht.md
+++ b/docs/TENANT_ONBOARDING.ht.md
@@ -1,0 +1,267 @@
+<!--
+Lang yo: English (TENANT_ONBOARDING.md) | Français (TENANT_ONBOARDING.fr.md) | Kreyòl (fichye sa a) | Español (TENANT_ONBOARDING.es.md)
+-->
+
+**Lang yo:** [English](TENANT_ONBOARDING.md) · [Français](TENANT_ONBOARDING.fr.md) · **Kreyòl Ayisyen** · [Español](TENANT_ONBOARDING.es.md)
+
+[← Endèks dokimantasyon](README.ht.md) · [README pwojè a](../README.md) · [Glosè](GLOSSARY.ht.md)
+
+---
+
+# Mete yon Vil Anplas (tenant onboarding)
+
+Kijan pou ajoute yon nouvo komin (yon « tenant ») sou yon deplwaman Haiti City Portal k ap mache. Dokiman sa pran swit apre [Deplwaman](DEPLOYMENT.ht.md).
+
+## Tablo Kontni
+
+- [Kisa yon tenant ye?](#kisa-yon-tenant-ye)
+- [Prerequi](#prerequi)
+- [Lis verifikasyon](#lis-verifikasyon)
+- [Etap 1 — Chwazi yon soudomèn](#etap-1--chwazi-yon-soudomèn)
+- [Etap 2 — Kreye liy tenant la](#etap-2--kreye-liy-tenant-la)
+- [Etap 3 — Verifye soudomèn nan reponn](#etap-3--verifye-soudomèn-nan-reponn)
+- [Etap 4 — Kreye premye itilizatè admin](#etap-4--kreye-premye-itilizatè-admin)
+- [Etap 5 — Ajoute ofisyèl ak seksyon kominal](#etap-5--ajoute-ofisyèl-ak-seksyon-kominal)
+- [Etap 6 — Ajoute etablisman](#etap-6--ajoute-etablisman)
+- [Etap 7 — Ajoute sèvis ak nouvèl](#etap-7--ajoute-sèvis-ak-nouvèl)
+- [Etap 8 — Pèsonalize tenant la](#etap-8--pèsonalize-tenant-la)
+- [Etap 9 — Fòme staf ak lanse](#etap-9--fòme-staf-ak-lanse)
+- [Chanje non oswa retire yon tenant](#chanje-non-oswa-retire-yon-tenant)
+- [Erè yo fè souvan](#erè-yo-fè-souvan)
+
+---
+
+## Kisa yon tenant ye?
+
+Yon **tenant** se yon komin. Chak liy nan baz done a (ofisyèl, demann, peyman, nouvèl) apatni a yon sèl tenant. Pòtal la sèvi nenpòt kantite tenant nan yon sèl aplikasyon — chak rive pa pwòp soudomèn li.
+
+Yon liy nan tab `tenants` se sous laverite. Kolòn `subdomain` lan pilote routaj. Si `tenants.subdomain = "jacmel"`, alò `https://jacmel.portal.ht` se pòtal komin sa a.
+
+Plis sou achitekti: [Achitekti](ARCHITECTURE.ht.md).
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Prerequi
+
+Anvan ou ajoute yon nouvo tenant:
+
+- Deplwaman pwodiksyon k ap mache ([Deplwaman](DEPLOYMENT.ht.md)).
+- DNS wildcard konfigire (`*.portal.ht`).
+- Domèn wildcard nan Vercel (**Settings → Domains**).
+- Aksè baz done (`DATABASE_URL`).
+
+Idantifye **sponsò tenant** (majistra oswa chèf kabinè) ak **lidè tenant** (anplwaye responsab kontni ak admin).
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Lis verifikasyon
+
+Pou chak nouvo komin:
+
+- [ ] Soudomèn chwazi
+- [ ] Liy tenant kreye
+- [ ] Soudomèn reponn ak HTTPS
+- [ ] Premye admin kreye
+- [ ] Seksyon kominal antre
+- [ ] Ofisyèl antre
+- [ ] Etablisman ajoute (oswa enpòte)
+- [ ] Sèvis dekri an MDX (oswa sekou anglè okòmansman)
+- [ ] Omwen yon atik nouvèl pibliye
+- [ ] Lòlò, koulè, foto majistra konfigire
+- [ ] Omwen de anplwaye fòme
+- [ ] Lansman restren
+- [ ] Lansman piblik
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Etap 1 — Chwazi yon soudomèn
+
+Idantifyan kout, fasil pou sonje, miniskil, san espas oswa karaktè espesyal.
+
+| Komin | Soudomèn sigjere |
+|---|---|
+| Jakmèl | `jacmel` |
+| Cap-Haïtien | `cap` oswa `capha` |
+| Pòtoprens | `pap` |
+| Pétion-Ville | `petionville` |
+| Les Cayes | `cayes` |
+| Croix-des-Bouquets | `croix` |
+
+URL final: `https://{subdomain}.portal.ht`.
+
+**Mo rezève pou evite:** `www`, `admin`, `api`, `static`, `assets`, `cdn`, `mail`, `email`, `app`, `staging`, `dev`, `test`, `localhost`, `demo`.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Etap 2 — Kreye liy tenant la
+
+De metòd.
+
+### Opsyon A — Script seed (rekòmande pou tou premye tenant)
+
+Wè [Deplwaman, etap 6.2](DEPLOYMENT.ht.md#etap-6--schema-inisyal-ak-seed). Script la kreye liy tenant ak superadmin nan menm fwa.
+
+### Opsyon B — Drizzle Studio (pou pwochèn komin)
+
+```bash
+npm run db:studio
+```
+
+1. Louvri tab `tenants`.
+2. **+ Add Record**.
+3. `name`: `Ville du Cap-Haïtien`. `subdomain`: `cap`.
+4. Sove. Note `id` (UUID) jenere a.
+
+### Opsyon C — SQL dirèk
+
+```sql
+INSERT INTO tenants (name, subdomain)
+VALUES ('Ville du Cap-Haïtien', 'cap')
+RETURNING id;
+```
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Etap 3 — Verifye soudomèn nan reponn
+
+Louvri `https://cap.portal.ht`. Paj akèy la dwe parèt ak non komin lan.
+
+Si « DB unavailable »:
+- CNAME wildcard DNS.
+- `*.portal.ht` nan Vercel **Settings → Domains**.
+- `subdomain` matche URL la (sansib pou kas, miniskil).
+- SSL pwovizyone (jiska 10 minit premye fwa).
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Etap 4 — Kreye premye itilizatè admin
+
+### Opsyon A — Drizzle Studio
+
+1. Tab `users` → **+ Add Record**.
+2. `tenant_id`: UUID etap 2. `email`: `admin@cap.portal.ht`.
+3. `password_hash`: hash bcrypt **pa modpas an klè**:
+   ```bash
+   node -e "console.log(require('bcryptjs').hashSync('MODPAS_OU', 10))"
+   ```
+4. `role`: `superadmin`. `name`: `Admin Cap-Haïtien`.
+5. Sove.
+
+### Opsyon B — SQL
+
+```sql
+INSERT INTO users (tenant_id, email, password_hash, role, name)
+VALUES ('<UUID>', 'admin@cap.portal.ht', '$2a$10$...', 'superadmin', 'Admin Cap-Haïtien');
+```
+
+Teste sou `https://cap.portal.ht/login`.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Etap 5 — Ajoute ofisyèl ak seksyon kominal
+
+### 5.1 Seksyon kominal
+
+Pou chak seksyon, liy nan `communal_sections`: `tenant_id`, `name` (« 1ère Section Bas Limbé »), `code` (`cap-1`).
+
+### 5.2 Ofisyèl
+
+Pou chak ofisyèl eli, liy nan `officials`: `tenant_id`, `name`, `role` (`casec`/`asec`/`mayor`/`town_delegate`), `communal_section_id`, `whatsapp`, `vwa_profile_url`, `photo_url`.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Etap 6 — Ajoute etablisman
+
+Liy nan `facilities`: `tenant_id`, `name`, `category` (hospital/school/police/church/market/other), `latitude`, `longitude`, `address`, `phone`.
+
+Konsèy: rezidan ka pwopoze koreksyon; yo rive nan `facility_suggestions`.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Etap 7 — Ajoute sèvis ak nouvèl
+
+Sèvis ak nouvèl yo se **fichye kontni**, pa liy BD. Wè [Gid Kontni](CONTENT_GUIDE.ht.md). Wit sèvis pa default yo ase pou pifò komin nan lansman.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Etap 8 — Pèsonalize tenant la
+
+Jodi a pèsonalizab pa tenant:
+- `name` nan navbar la.
+- `subdomain`.
+- Foto atravè `officials.photo_url`.
+
+Lòlò pèsonalize ak koulè sou plan. Annatant: mete vizyèl ou nan `public/tenants/{subdomain}/`.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Etap 9 — Fòme staf ak lanse
+
+Distribiye [Manyèl Administrasyon](ADMIN_MANUAL.ht.md). Sesyon 1–2 èdtan: koneksyon, demann, verifikasyon peyman, nouvèl, alèt, pasaj. Apre lansman restren, apre lansman piblik.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Chanje non oswa retire yon tenant
+
+### Chanje non
+
+`name` ka chanje. `subdomain` dwe rete stab. Si w dwe chanje l: kreye nouvo a, redirije ansyen an, kominike 90 jou.
+
+### Retire
+
+Backup dabò. Retire liy depandan anvan `tenants`:
+
+```sql
+DELETE FROM payment_records WHERE tenant_id = '<UUID>';
+DELETE FROM service_requests WHERE tenant_id = '<UUID>';
+DELETE FROM facilities WHERE tenant_id = '<UUID>';
+-- ... pou chak tab antite ...
+DELETE FROM tenants WHERE id = '<UUID>';
+```
+
+Pi bon: achive olye retire.
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+## Erè yo fè souvan
+
+| Erè | Senptòm | Koreksyon |
+|---|---|---|
+| `*.portal.ht` pa nan Vercel | 404 | Settings → Domains |
+| Soudomèn an majiskil | Tenant pa jwenn | Miniskil sèlman |
+| Modpas an klè nan `password_hash` | Login toujou echwe | Jenere yon hash bcrypt |
+| `tenant_id` bliye | Liy envizib | Met liy lan ajou |
+| De tenant menm `subdomain` | Routaj endefini | Kontrent inisite |
+| Mo rezève kòm subdomain | Konfli | Chwazi yon lòt non |
+
+[↑ Retounen anwo](#tablo-kontni)
+
+---
+
+[← Endèks dokimantasyon](README.ht.md) · [Deplwaman](DEPLOYMENT.ht.md) · [Manyèl Administrasyon →](ADMIN_MANUAL.ht.md)

--- a/docs/TENANT_ONBOARDING.md
+++ b/docs/TENANT_ONBOARDING.md
@@ -1,0 +1,355 @@
+<!--
+Languages: English (this file) | Français (TENANT_ONBOARDING.fr.md) | Kreyòl (TENANT_ONBOARDING.ht.md) | Español (TENANT_ONBOARDING.es.md)
+-->
+
+**Languages:** **English** · [Français](TENANT_ONBOARDING.fr.md) · [Kreyòl Ayisyen](TENANT_ONBOARDING.ht.md) · [Español](TENANT_ONBOARDING.es.md)
+
+[← Docs index](README.md) · [Project README](../README.md) · [Glossary](GLOSSARY.md)
+
+---
+
+# Tenant Onboarding
+
+How to add a new commune (a "tenant") to a running Haiti City Portal deployment. This document picks up where [Deployment](DEPLOYMENT.md) left off.
+
+## Table of Contents
+
+- [What is a tenant?](#what-is-a-tenant)
+- [Prerequisites](#prerequisites)
+- [Onboarding checklist](#onboarding-checklist)
+- [Step 1 — Pick a subdomain](#step-1--pick-a-subdomain)
+- [Step 2 — Create the tenant row](#step-2--create-the-tenant-row)
+- [Step 3 — Verify the subdomain resolves](#step-3--verify-the-subdomain-resolves)
+- [Step 4 — Create the first admin user](#step-4--create-the-first-admin-user)
+- [Step 5 — Add officials and communal sections](#step-5--add-officials-and-communal-sections)
+- [Step 6 — Add facilities](#step-6--add-facilities)
+- [Step 7 — Add services and news](#step-7--add-services-and-news)
+- [Step 8 — Brand the tenant](#step-8--brand-the-tenant)
+- [Step 9 — Train staff and launch](#step-9--train-staff-and-launch)
+- [Removing or renaming a tenant](#removing-or-renaming-a-tenant)
+- [Common mistakes](#common-mistakes)
+
+---
+
+## What is a tenant?
+
+A **tenant** is one commune. Every record in the database (officials, requests, payments, news) belongs to exactly one tenant. The portal serves any number of tenants from a single running application — each is reached by its own subdomain.
+
+A row in the `tenants` table is the source of truth. Its `subdomain` column drives routing. If `tenants.subdomain = "jacmel"`, then `https://jacmel.portal.ht` is that commune's portal.
+
+For more on the architecture, see [Architecture](ARCHITECTURE.md).
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Prerequisites
+
+Before adding a new tenant you must already have:
+
+- A working production deployment ([Deployment](DEPLOYMENT.md)).
+- Wildcard DNS configured (`*.portal.ht`).
+- A wildcard domain registered with Vercel (`*.portal.ht` in **Settings → Domains**).
+- Database access (your `DATABASE_URL`).
+
+Decide who will be the **tenant sponsor** at the commune (typically the mayor or chief of staff) and the **tenant lead** (the staff member responsible for content and admin work).
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Onboarding checklist
+
+Print or copy this checklist and complete it for every new commune.
+
+- [ ] Subdomain decided
+- [ ] Tenant row created
+- [ ] Subdomain resolves with HTTPS
+- [ ] First admin user created
+- [ ] Communal sections added
+- [ ] Officials added
+- [ ] Facilities added (or imported)
+- [ ] Services described in MDX (or English fallback only at first)
+- [ ] At least one news article published
+- [ ] Logo, colours, mayor photo configured
+- [ ] Two staff members trained
+- [ ] Soft launch
+- [ ] Public launch
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Step 1 — Pick a subdomain
+
+Pick a short, memorable, lowercase identifier without spaces or special characters.
+
+| Commune | Suggested subdomain |
+|---|---|
+| Jacmel | `jacmel` |
+| Cap-Haïtien | `cap` or `capha` |
+| Port-au-Prince | `pap` |
+| Pétion-Ville | `petionville` |
+| Les Cayes | `cayes` |
+| Croix-des-Bouquets | `croix` |
+
+The full URL becomes `https://{subdomain}.portal.ht` (or whatever apex domain you use).
+
+**Reserved words you cannot use as subdomains:** `www`, `admin`, `api`, `static`, `assets`, `cdn`, `mail`, `email`, `app`, `staging`, `dev`, `test`, `localhost`, `demo`.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Step 2 — Create the tenant row
+
+Two ways to create the tenant row.
+
+### Option A — Production seed script (recommended for the first tenant)
+
+If this is the deployment's *first* tenant and you want both a tenant row and a superadmin user in one shot, use the seed script — see [Deployment, Step 6.2](DEPLOYMENT.md#step-6--initial-schema-and-seed). It's safe to run multiple times because it checks for existing rows.
+
+### Option B — Drizzle Studio (recommended for additional tenants)
+
+For the second, third, or hundredth commune, use the visual database editor:
+
+1. From your laptop, with `DATABASE_URL` pointing to production:
+
+   ```bash
+   npm run db:studio
+   ```
+
+2. Drizzle Studio opens at <https://local.drizzle.studio>.
+3. Open the `tenants` table.
+4. Click **+ Add Record**.
+5. Fill in:
+   - `name`: `Ville de Cap-Haïtien` (display name, can include accents)
+   - `subdomain`: `cap` (the URL-safe one from Step 1)
+   - `created_at`: leave default
+6. Save.
+7. Note the generated `id` (UUID) — you'll need it for Step 4 if creating an admin manually.
+
+### Option C — SQL directly
+
+If you prefer raw SQL via `psql` or any database client:
+
+```sql
+INSERT INTO tenants (name, subdomain)
+VALUES ('Ville de Cap-Haïtien', 'cap')
+RETURNING id;
+```
+
+The `RETURNING id;` clause gives you the generated UUID.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Step 3 — Verify the subdomain resolves
+
+Open `https://cap.portal.ht` in a browser. You should see the homepage with the commune's name.
+
+If you see "DB unavailable, using fallback tenant", check:
+
+- The wildcard CNAME in DNS.
+- The wildcard `*.portal.ht` is added in Vercel **Settings → Domains**.
+- The tenant row's `subdomain` column matches the URL (case-sensitive, lowercase).
+- SSL has finished provisioning (can take up to 10 minutes the first time).
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Step 4 — Create the first admin user
+
+The new tenant has no users yet. Pick one of:
+
+### Option A — Drizzle Studio
+
+1. In Drizzle Studio, open the `users` table.
+2. Click **+ Add Record**.
+3. Fill in:
+   - `tenant_id`: paste the UUID from Step 2.
+   - `email`: e.g. `admin@cap.portal.ht`
+   - `password_hash`: this must be a bcrypt hash, **not the plaintext password**. Generate one:
+     ```bash
+     node -e "console.log(require('bcryptjs').hashSync('YOUR_PASSWORD', 10))"
+     ```
+     Paste the resulting `$2a$10$...` string into the `password_hash` column.
+   - `role`: `superadmin`
+   - `name`: `Admin Cap-Haïtien` (or the actual person's name)
+4. Save.
+
+### Option B — SQL
+
+```sql
+INSERT INTO users (tenant_id, email, password_hash, role, name)
+VALUES (
+  '<TENANT_UUID>',
+  'admin@cap.portal.ht',
+  '$2a$10$...',  -- bcrypt hash, see above
+  'superadmin',
+  'Admin Cap-Haïtien'
+);
+```
+
+Test by visiting `https://cap.portal.ht/login` and signing in.
+
+> **Tip:** Once one admin can sign in, they can create additional admin users from inside the admin panel — no more SQL required for the next staff members.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Step 5 — Add officials and communal sections
+
+A commune is composed of one or more **communal sections** (sub-municipal units). Each section has elected officials (CASEC, ASEC). The mayor sits at the commune level.
+
+### 5.1 Add communal sections
+
+For each section of the commune, create a row in `communal_sections`:
+
+| Column | Example |
+|---|---|
+| `tenant_id` | UUID of the commune |
+| `name` | `1ère Section Bas Limbé` |
+| `code` | `cap-1` (a short, stable code) |
+
+### 5.2 Add officials
+
+For each elected official, create a row in `officials`:
+
+| Column | Example |
+|---|---|
+| `tenant_id` | UUID of the commune |
+| `name` | `Marie Joseph` |
+| `role` | `casec` / `asec` / `mayor` / `town_delegate` |
+| `communal_section_id` | UUID of the section (NULL for mayor / town delegate) |
+| `whatsapp` | `+509xxxxxxxx` (optional) |
+| `vwa_profile_url` | `https://haitiansintech.com/profile/...` (optional) |
+| `photo_url` | URL to a photo (optional) |
+
+You can do this in Drizzle Studio, or build a small CSV importer if you have many officials.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Step 6 — Add facilities
+
+The facilities directory holds hospitals, schools, police stations, churches, and other public points of interest with GPS coordinates.
+
+For each facility, create a row in `facilities`:
+
+| Column | Example |
+|---|---|
+| `tenant_id` | UUID of the commune |
+| `name` | `Hôpital Saint Michel` |
+| `category` | `hospital` / `school` / `police` / `church` / `market` / `other` |
+| `latitude` | `18.0067` |
+| `longitude` | `-72.5364` |
+| `address` | `Rue Comédie, Jacmel` |
+| `phone` | `+509xxxxxxxx` (optional) |
+
+Tip: residents can submit corrections through the directory page; these go into `facility_suggestions` for an admin to review.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Step 7 — Add services and news
+
+Services and news articles are **content files**, not database rows. They live in `src/content/services/` and `src/content/news/`. Editors can use the GitHub web UI — no Git or coding required. See [Content Guide](CONTENT_GUIDE.md).
+
+For multi-tenant deployments, services and news in `src/content/` are *shared across all tenants by default*. If a commune needs a service that's specific to it, add a tenant-scoped row in the `services` table (or in `service_definitions` for richer schemas) and customise the route.
+
+For most communes, the eight default services (birth certificates, cleanup, culture, governance, national-id, permits, towing, trash) are sufficient at launch.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Step 8 — Brand the tenant
+
+Today the portal supports per-tenant:
+
+- `name` (display name shown in the navbar)
+- `subdomain` (URL key)
+- Mayor and officials photos (uploaded to your file storage; URLs stored in `officials.photo_url`)
+
+Future per-tenant branding (logo upload, custom colours) is on the roadmap. Until then, communes can:
+- Place their official photos and seal in `public/tenants/{subdomain}/` and reference them.
+- Update the homepage hero text in `messages/{locale}.json` for shared text, or in tenant-specific MDX content for tenant-specific text.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Step 9 — Train staff and launch
+
+Distribute [Admin Manual](ADMIN_MANUAL.md) to staff who will use the portal day-to-day. Run a 1–2 hour training session covering:
+
+1. Logging in.
+2. Reading and updating service requests.
+3. Verifying a payment.
+4. Publishing a news article.
+5. Posting an emergency alert.
+6. Handing over to the next shift.
+
+Then:
+
+- **Soft launch:** announce internally and to a small group of residents (e.g. a single neighbourhood). Collect feedback for 1–2 weeks.
+- **Public launch:** mayor's office press release, social media, banners at city hall.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Removing or renaming a tenant
+
+### Renaming
+
+Update the `name` column in the `tenants` row. The `subdomain` should remain stable — changing it breaks every existing URL and bookmarks.
+
+If you must change the subdomain:
+1. Add the new subdomain (`cap` → `cap-haitien`).
+2. Set up a redirect at the DNS or middleware level from the old subdomain to the new.
+3. Communicate the change for at least 90 days.
+
+### Removing
+
+Removing a tenant means removing rows in dependent tables first (because of foreign keys):
+
+```sql
+DELETE FROM payment_records WHERE tenant_id = '<UUID>';
+DELETE FROM service_requests WHERE tenant_id = '<UUID>';
+DELETE FROM facilities WHERE tenant_id = '<UUID>';
+DELETE FROM officials WHERE tenant_id = '<UUID>';
+DELETE FROM communal_sections WHERE tenant_id = '<UUID>';
+DELETE FROM users WHERE tenant_id = '<UUID>';
+-- (continue for every entity table)
+DELETE FROM tenants WHERE id = '<UUID>';
+```
+
+Strongly recommended: **backup first**, and consider archiving instead of deleting. A well-formed `archived_at` column on `tenants` is a future improvement worth contributing.
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+## Common mistakes
+
+| Mistake | Symptom | Fix |
+|---|---|---|
+| Forgot to add `*.portal.ht` to Vercel domains | Subdomain returns 404 | Add it in Settings → Domains |
+| Subdomain has uppercase letters | Tenant lookup fails | Subdomains are case-sensitive in routing — use lowercase only |
+| Stored plaintext password in `password_hash` | Login always fails | Generate a bcrypt hash and update the row |
+| Forgot `tenant_id` on a row | Row is invisible to all tenants | Update the row to include the correct `tenant_id` |
+| Two tenants share a subdomain | Routing is undefined | Database should enforce a unique constraint; check `subdomain` uniqueness |
+| Used a reserved word as subdomain (`api`, `admin`, `www`…) | Conflicts with system routes | Pick a different subdomain |
+
+[↑ Back to top](#table-of-contents)
+
+---
+
+[← Docs index](README.md) · [Deployment](DEPLOYMENT.md) · [Admin Manual →](ADMIN_MANUAL.md)

--- a/docs/adr/0001-multi-tenant-via-subdomain.es.md
+++ b/docs/adr/0001-multi-tenant-via-subdomain.es.md
@@ -1,0 +1,47 @@
+<!--
+Idiomas: English (0001-multi-tenant-via-subdomain.md) | Français (...fr.md) | Kreyòl (...ht.md) | Español (este archivo)
+-->
+
+**Idiomas:** [English](0001-multi-tenant-via-subdomain.md) · [Français](0001-multi-tenant-via-subdomain.fr.md) · [Kreyòl Ayisyen](0001-multi-tenant-via-subdomain.ht.md) · **Español**
+
+[← Índice de ADR](README.es.md) · [Arquitectura](../ARCHITECTURE.es.md)
+
+---
+
+# 0001 — Multi-tenant vía subdominio + middleware
+
+- **Estado:** Aceptado
+- **Fecha:** 2025-09-01
+- **Decisores:** mantenedores del proyecto
+
+## Contexto
+
+El portal debe servir muchas comunas desde una sola aplicación, manteniendo aislados los datos. Tres patrones:
+
+1. **Base por tenant**.
+2. **Esquema por tenant** en una base compartida.
+3. **Scoping por fila con `tenant_id`** — esquema compartido, cada fila marcada con su tenant.
+
+Restricciones: agregar comuna sin redespliegue; costo Vercel + Neon; mayoría de consultas scoped.
+
+## Decisión
+
+**Scoping por fila con `tenant_id`**. Resolución de tenant en middleware: subdominio extraído de `Host` y escrito en cabecera de servidor `x-tenant-subdomain` que leen los Server Components.
+
+Cada tabla (excepto `tenants`) tiene una columna `tenant_id uuid NOT NULL` con FK a `tenants.id`. Cada consulta filtra por ella.
+
+## Consecuencias
+
+**Positivas:** agregar una comuna = un INSERT + DNS comodín ya configurado; costo de base única; agregaciones nacionales triviales.
+
+**Negativas:** olvidar `tenant_id` = incidente crítico (mitigado con revisión de código); respaldos globales; rendimiento afectado si una comuna domina.
+
+**Neutras:** `x-tenant-subdomain` *nunca* se confía desde el cliente — middleware la escribe.
+
+## Alternativas consideradas
+
+- **Base por tenant**: demasiado caro, operacionalmente pesado.
+- **Esquema por tenant**: migraciones Drizzle complicadas; beneficios marginales.
+- **Tenant por path** (`/jacmel/services`): conflicto con prefijos de locale y URL menos profesional.
+
+[↑ Volver arriba](#0001--multi-tenant-vía-subdominio--middleware) · [← Índice de ADR](README.es.md) · [Siguiente: 0002 →](0002-uuid-primary-keys.es.md)

--- a/docs/adr/0001-multi-tenant-via-subdomain.fr.md
+++ b/docs/adr/0001-multi-tenant-via-subdomain.fr.md
@@ -1,0 +1,47 @@
+<!--
+Langues : English (0001-multi-tenant-via-subdomain.md) | Français (ce fichier) | Kreyòl (...ht.md) | Español (...es.md)
+-->
+
+**Langues :** [English](0001-multi-tenant-via-subdomain.md) · **Français** · [Kreyòl Ayisyen](0001-multi-tenant-via-subdomain.ht.md) · [Español](0001-multi-tenant-via-subdomain.es.md)
+
+[← Index des ADR](README.fr.md) · [Architecture](../ARCHITECTURE.fr.md)
+
+---
+
+# 0001 — Multi-tenant par sous-domaine + middleware
+
+- **Statut :** Accepté
+- **Date :** 2025-09-01
+- **Décideurs :** mainteneurs du projet
+
+## Contexte
+
+Le portail doit servir de nombreuses communes depuis une seule application, tout en isolant strictement les données. Trois schémas envisagés :
+
+1. **Une base par tenant**.
+2. **Un schéma par tenant** dans une base partagée.
+3. **Scoping par ligne avec `tenant_id`** — schéma partagé, chaque ligne marquée par son tenant.
+
+Contraintes : ajout d'une commune sans redéploiement ; coût Vercel + Neon ; majorité de requêtes scoped par tenant.
+
+## Décision
+
+**Scoping par ligne avec `tenant_id`**. Résolution du tenant dans le middleware : sous-domaine extrait du `Host` et écrit dans l'en-tête serveur `x-tenant-subdomain` lu par les Server Components.
+
+Chaque table (sauf `tenants`) a une colonne `tenant_id uuid NOT NULL` avec FK vers `tenants.id`. Chaque requête filtre dessus.
+
+## Conséquences
+
+**Positives :** ajout d'une commune = un INSERT + DNS wildcard déjà en place ; coût base unique ; agrégations nationales triviales.
+
+**Négatives :** un oubli de `tenant_id` = incident critique (atténué par revue de code) ; sauvegardes globales ; performance impactée si une commune domine.
+
+**Neutres :** `x-tenant-subdomain` n'est *jamais* cru depuis le client — le middleware l'écrit.
+
+## Alternatives examinées
+
+- **Base par tenant** : trop chère, lourde à opérer.
+- **Schéma par tenant** : migrations Drizzle pénibles ; bénéfices marginaux.
+- **Tenant par chemin** (`/jacmel/services`) : conflit avec les préfixes locale et URL moins pro.
+
+[↑ Retour en haut](#0001--multi-tenant-par-sous-domaine--middleware) · [← Index des ADR](README.fr.md) · [Suivant : 0002 →](0002-uuid-primary-keys.fr.md)

--- a/docs/adr/0001-multi-tenant-via-subdomain.ht.md
+++ b/docs/adr/0001-multi-tenant-via-subdomain.ht.md
@@ -1,0 +1,47 @@
+<!--
+Lang yo: English (0001-multi-tenant-via-subdomain.md) | Français (...fr.md) | Kreyòl (fichye sa a) | Español (...es.md)
+-->
+
+**Lang yo:** [English](0001-multi-tenant-via-subdomain.md) · [Français](0001-multi-tenant-via-subdomain.fr.md) · **Kreyòl Ayisyen** · [Español](0001-multi-tenant-via-subdomain.es.md)
+
+[← Endèks ADR](README.ht.md) · [Achitekti](../ARCHITECTURE.ht.md)
+
+---
+
+# 0001 — Multi-tenant atravè soudomèn + middleware
+
+- **Estati:** Aksepte
+- **Dat:** 2025-09-01
+- **Desidè:** mainteneurs pwojè a
+
+## Kontèks
+
+Pòtal la dwe sèvi anpil komin depi yon sèl aplikasyon, ak izolasyon estrik done yo. Twa modèl konsidere:
+
+1. **Yon baz pa tenant**.
+2. **Yon schema pa tenant** nan yon baz pataje.
+3. **Scoping pa liy ak `tenant_id`** — schema pataje, chak liy make ak tenant li.
+
+Kontrent: ajoute yon komin san redeplwaman; pri Vercel + Neon; majorite rekèt scoped.
+
+## Desizyon
+
+**Scoping pa liy ak `tenant_id`**. Rezolisyon tenant nan middleware: soudomèn ekstrè soti nan `Host` epi ekri nan antèt sèvè `x-tenant-subdomain` Server Components li.
+
+Chak tab (sof `tenants`) gen yon kolòn `tenant_id uuid NOT NULL` ak FK sou `tenants.id`. Chak rekèt filtre sou li.
+
+## Konsekans
+
+**Pozitif:** ajoute yon komin = yon INSERT + DNS wildcard deja la; pri baz inik; agregasyon nasyonal trivial.
+
+**Negatif:** yon `tenant_id` bliye = ensidan kritik (atenue pa revizyon kòd); backup global; pèfòmans afekte si yon komin dominan.
+
+**Nyout:** `x-tenant-subdomain` *pa janm* kwè soti nan kliyan — middleware ekri li.
+
+## Altènativ konsidere
+
+- **Baz pa tenant**: twò chè, lou pou opere.
+- **Schema pa tenant**: migrasyon Drizzle difisil; benefis maj.
+- **Tenant pa chemen** (`/jacmel/services`): konfli ak prefiks lokal ak URL mwens pwofesyonèl.
+
+[↑ Retounen anwo](#0001--multi-tenant-atravè-soudomèn--middleware) · [← Endèks ADR](README.ht.md) · [Pwochen: 0002 →](0002-uuid-primary-keys.ht.md)

--- a/docs/adr/0001-multi-tenant-via-subdomain.md
+++ b/docs/adr/0001-multi-tenant-via-subdomain.md
@@ -1,0 +1,58 @@
+<!--
+Languages: English (this file) | Français (0001-multi-tenant-via-subdomain.fr.md) | Kreyòl (0001-multi-tenant-via-subdomain.ht.md) | Español (0001-multi-tenant-via-subdomain.es.md)
+-->
+
+**Languages:** **English** · [Français](0001-multi-tenant-via-subdomain.fr.md) · [Kreyòl Ayisyen](0001-multi-tenant-via-subdomain.ht.md) · [Español](0001-multi-tenant-via-subdomain.es.md)
+
+[← ADR index](README.md) · [Architecture](../ARCHITECTURE.md)
+
+---
+
+# 0001 — Multi-tenancy via subdomain + middleware
+
+- **Status:** Accepted
+- **Date:** 2025-09-01
+- **Deciders:** project maintainers
+
+## Context
+
+Haiti City Portal must serve many communes from one running application, while keeping each commune's data strictly isolated. We considered three patterns:
+
+1. **Database-per-tenant** — one Postgres database per commune.
+2. **Schema-per-tenant** — one schema per commune in a shared database.
+3. **Row-level scoping with `tenant_id`** — one shared schema, each row tagged with its tenant.
+
+Constraints:
+- Adding a new commune must require zero deploys and minimal IT work.
+- Cross-tenant queries (e.g. "all officials") must remain rare or forbidden.
+- Hosting on Vercel + Neon — both make multiple databases expensive.
+- Most queries are tenant-scoped reads.
+
+## Decision
+
+We use **row-level scoping with `tenant_id`**. Tenant resolution happens in middleware: subdomain is extracted from the `Host` header and written to a server-side `x-tenant-subdomain` header that downstream Server Components read.
+
+Every table (except `tenants` itself) has a `tenant_id uuid NOT NULL` column with a foreign key to `tenants.id`. Every query filters by it.
+
+## Consequences
+
+**Positive:**
+- Adding a commune is one row insert plus a DNS wildcard already in place — no deploy.
+- Single-database hosting cost.
+- Trivial cross-tenant aggregations are possible (e.g. national statistics) without rejoining databases.
+
+**Negative:**
+- A bug that omits a `tenant_id` filter is a critical security issue. Mitigated by lint rules and code review.
+- Backups are global; restoring a single commune requires extracting rows.
+- Performance can degrade when one commune dominates the database.
+
+**Neutral:**
+- The `x-tenant-subdomain` header must never be trusted from external requests — middleware writes it.
+
+## Alternatives considered
+
+- **Database-per-tenant**: too expensive on Neon and operationally heavy.
+- **Schema-per-tenant**: per-schema migrations are painful with Drizzle; benefits are marginal versus row scoping.
+- **Path-based tenancy** (e.g. `/jacmel/services`): conflicts with locale prefixes (`/ht/services`) and gives a less professional URL.
+
+[↑ Back to top](#0001--multi-tenancy-via-subdomain--middleware) · [← ADR index](README.md) · [Next: 0002 →](0002-uuid-primary-keys.md)

--- a/docs/adr/0002-uuid-primary-keys.es.md
+++ b/docs/adr/0002-uuid-primary-keys.es.md
@@ -1,0 +1,36 @@
+**Idiomas:** [English](0002-uuid-primary-keys.md) · [Français](0002-uuid-primary-keys.fr.md) · [Kreyòl Ayisyen](0002-uuid-primary-keys.ht.md) · **Español**
+
+[← Índice de ADR](README.es.md) · [Arquitectura](../ARCHITECTURE.es.md)
+
+---
+
+# 0002 — Claves primarias UUID en todas las tablas
+
+- **Estado:** Aceptado
+- **Fecha:** 2025-09-01
+- **Decisores:** mantenedores del proyecto
+
+## Contexto
+
+Cada tabla necesita PK. Opciones: enteros secuenciales o UUID.
+
+Restricciones: modo offline (generación sin colisión); multi-tenant (IDs secuenciales revelan volumen); URLs uniformes entre comunas.
+
+## Decisión
+
+Cada PK es `uuid("id").defaultRandom().primaryKey()`. Sin excepción. Las FK referencian estos UUID.
+
+## Consecuencias
+
+**Positivas:** generación offline segura; aislamiento tenant preservado; URLs uniformes.
+
+**Negativas:** tamaño (16 vs 4–8 bytes); no legibles (mitigado con códigos memo `JAC-TAX-8821`); fragmentación B-tree a escala (UUIDv7 opción futura).
+
+**Neutras:** regla a conocer por cada nuevo colaborador.
+
+## Alternativas consideradas
+
+- **Enteros secuenciales**: violan requisitos offline y de aislamiento.
+- **UUIDv7 / ULID**: ruta de migración aceptable a futuro.
+
+[↑ Volver arriba](#0002--claves-primarias-uuid-en-todas-las-tablas) · [← Anterior: 0001](0001-multi-tenant-via-subdomain.es.md) · [Índice de ADR](README.es.md) · [Siguiente: 0003 →](0003-mdx-content-vs-database.es.md)

--- a/docs/adr/0002-uuid-primary-keys.fr.md
+++ b/docs/adr/0002-uuid-primary-keys.fr.md
@@ -1,0 +1,36 @@
+**Langues :** [English](0002-uuid-primary-keys.md) · **Français** · [Kreyòl Ayisyen](0002-uuid-primary-keys.ht.md) · [Español](0002-uuid-primary-keys.es.md)
+
+[← Index des ADR](README.fr.md) · [Architecture](../ARCHITECTURE.fr.md)
+
+---
+
+# 0002 — Clés primaires UUID partout
+
+- **Statut :** Accepté
+- **Date :** 2025-09-01
+- **Décideurs :** mainteneurs du projet
+
+## Contexte
+
+Toute table a besoin d'une PK. Choix classiques : entiers séquentiels ou UUID.
+
+Contraintes : mode hors-ligne (génération sans collision) ; multi-tenant (les IDs séquentiels révèlent le volume) ; URLs uniformes entre communes.
+
+## Décision
+
+Chaque PK est `uuid("id").defaultRandom().primaryKey()`. Pas d'exception. Les FK référencent ces UUID.
+
+## Conséquences
+
+**Positives :** génération hors-ligne sûre ; isolation tenant préservée ; URLs uniformes.
+
+**Négatives :** taille (16 vs 4–8 octets) ; non-lisibles (atténué par codes mémo `JAC-TAX-8821`) ; fragmentation B-tree à grande échelle (UUIDv7 en option future).
+
+**Neutres :** règle à connaître pour tout nouveau contributeur.
+
+## Alternatives examinées
+
+- **Entiers séquentiels** : violent les exigences hors-ligne et isolation.
+- **UUIDv7 / ULID** : voie de migration acceptable plus tard.
+
+[↑ Retour en haut](#0002--clés-primaires-uuid-partout) · [← Précédent : 0001](0001-multi-tenant-via-subdomain.fr.md) · [Index des ADR](README.fr.md) · [Suivant : 0003 →](0003-mdx-content-vs-database.fr.md)

--- a/docs/adr/0002-uuid-primary-keys.ht.md
+++ b/docs/adr/0002-uuid-primary-keys.ht.md
@@ -1,0 +1,36 @@
+**Lang yo:** [English](0002-uuid-primary-keys.md) · [Français](0002-uuid-primary-keys.fr.md) · **Kreyòl Ayisyen** · [Español](0002-uuid-primary-keys.es.md)
+
+[← Endèks ADR](README.ht.md) · [Achitekti](../ARCHITECTURE.ht.md)
+
+---
+
+# 0002 — Kle prensipal UUID nan tout tab
+
+- **Estati:** Aksepte
+- **Dat:** 2025-09-01
+- **Desidè:** mainteneurs pwojè a
+
+## Kontèks
+
+Chak tab bezwen yon PK. Chwa: antye sekansyèl oswa UUID.
+
+Kontrent: mòd ofliy (jenerasyon san kolizyon); multi-tenant (ID sekansyèl revele volim); URL inifòm ant komin.
+
+## Desizyon
+
+Chak PK se `uuid("id").defaultRandom().primaryKey()`. Pa gen eksepsyon. FK refere UUID sa yo.
+
+## Konsekans
+
+**Pozitif:** jenerasyon ofliy san pwoblèm; izolasyon tenant pwoteje; URL inifòm.
+
+**Negatif:** gwosè (16 vs 4–8 byte); pa lizib (atenue ak kòd memo `JAC-TAX-8821`); fragmentasyon B-tree sou gwo echèl (UUIDv7 opsyon pou pita).
+
+**Nyout:** règ pou chak nouvo kontribitè dwe konnen.
+
+## Altènativ konsidere
+
+- **Antye sekansyèl**: vyole egzijans ofliy ak izolasyon.
+- **UUIDv7 / ULID**: chemen migrasyon akseptab pou pita.
+
+[↑ Retounen anwo](#0002--kle-prensipal-uuid-nan-tout-tab) · [← Anvan: 0001](0001-multi-tenant-via-subdomain.ht.md) · [Endèks ADR](README.ht.md) · [Pwochen: 0003 →](0003-mdx-content-vs-database.ht.md)

--- a/docs/adr/0002-uuid-primary-keys.md
+++ b/docs/adr/0002-uuid-primary-keys.md
@@ -1,0 +1,52 @@
+<!--
+Languages: English (this file) | Français (0002-uuid-primary-keys.fr.md) | Kreyòl (0002-uuid-primary-keys.ht.md) | Español (0002-uuid-primary-keys.es.md)
+-->
+
+**Languages:** **English** · [Français](0002-uuid-primary-keys.fr.md) · [Kreyòl Ayisyen](0002-uuid-primary-keys.ht.md) · [Español](0002-uuid-primary-keys.es.md)
+
+[← ADR index](README.md) · [Architecture](../ARCHITECTURE.md)
+
+---
+
+# 0002 — UUID primary keys for every table
+
+- **Status:** Accepted
+- **Date:** 2025-09-01
+- **Deciders:** project maintainers
+
+## Context
+
+Every table needs a primary key. The two common choices are sequential integers (`SERIAL` / `BIGSERIAL`) and UUIDs.
+
+Project constraints:
+- Offline support is on the roadmap. Forms submitted offline must generate IDs that won't collide when synced.
+- Multi-tenant: leaking sequential IDs across tenants exposes business volume (e.g. "they only have 12 users").
+- We want IDs that look the same in URLs across all tenants — no `/requests/1` vs `/requests/14882`.
+
+## Decision
+
+Every primary key is `uuid("id").defaultRandom().primaryKey()`. No exceptions.
+
+Foreign keys reference these UUIDs.
+
+## Consequences
+
+**Positive:**
+- Offline ID generation is safe.
+- Tenant isolation is preserved: looking at a UUID tells you nothing about volume.
+- URLs are uniform across tenants.
+
+**Negative:**
+- UUIDs are larger (16 bytes vs 4 or 8) — minor storage and index overhead.
+- UUIDs are not human-readable. Mitigated by adding human-readable codes (e.g. `JAC-TAX-8821` memo codes) where users see IDs.
+- B-tree fragmentation with random UUIDs can be a concern at scale; we accept the tradeoff and may revisit with UUIDv7 later.
+
+**Neutral:**
+- All migrations and ORM generators now produce UUIDs by default; new contributors must remember the rule.
+
+## Alternatives considered
+
+- **Sequential integers**: violates offline-ID and tenant-isolation requirements.
+- **UUIDv7 / ULID**: time-ordered alternatives that improve B-tree locality. Acceptable upgrade path; not blocking now.
+
+[↑ Back to top](#0002--uuid-primary-keys-for-every-table) · [← Previous: 0001](0001-multi-tenant-via-subdomain.md) · [ADR index](README.md) · [Next: 0003 →](0003-mdx-content-vs-database.md)

--- a/docs/adr/0003-mdx-content-vs-database.es.md
+++ b/docs/adr/0003-mdx-content-vs-database.es.md
@@ -1,0 +1,39 @@
+**Idiomas:** [English](0003-mdx-content-vs-database.md) · [Français](0003-mdx-content-vs-database.fr.md) · [Kreyòl Ayisyen](0003-mdx-content-vs-database.ht.md) · **Español**
+
+[← Índice de ADR](README.es.md) · [Arquitectura](../ARCHITECTURE.es.md)
+
+---
+
+# 0003 — Contenido de prosa en archivos MDX, no en la base
+
+- **Estado:** Aceptado
+- **Fecha:** 2025-09-01
+- **Decisores:** mantenedores del proyecto
+
+## Contexto
+
+El portal necesita prosa en cuatro idiomas: descripciones de servicios, noticias, páginas legales. Tres opciones: todo en base, CMS headless de terceros (Sanity, Contentful…), archivos MDX en el repo.
+
+Restricciones: traducción por no-desarrolladores; historial auditable; sin suscripciones SaaS recurrentes que bloqueen comunas con pocos recursos; revisión tipo código (PR + diff).
+
+## Decisión
+
+Prosa en `src/content/**/*.mdx`. Etiquetas cortas en `messages/{locale}.json`. Campos dinámicos admin en columnas JSONB.
+
+Traductores editan vía web de GitHub; vea [Guía de Contenido](../CONTENT_GUIDE.es.md).
+
+## Consecuencias
+
+**Positivas:** gratis; historial Git completo; PR para contenido como para código; fallback de locale = simple lectura de archivo; contenido portátil.
+
+**Negativas:** cambios en producción requieren redespliegue (Vercel lo hace instantáneo); traductores deben aprender GitHub (~30 min); ediciones masivas vía múltiples PR o imports CSV.
+
+**Neutras:** UI admin para editar MDX en navegador en hoja de ruta; almacenamiento igual.
+
+## Alternativas consideradas
+
+- **Todo en base**: traducción difícil sin CMS; sin historial.
+- **CMS headless**: costo recurrente; bloqueo de proveedor; otro login para editores.
+- **Decap CMS** (Git, open-source): adición futura que *complementa* MDX en lugar de reemplazarlo.
+
+[↑ Volver arriba](#0003--contenido-de-prosa-en-archivos-mdx-no-en-la-base) · [← Anterior: 0002](0002-uuid-primary-keys.es.md) · [Índice de ADR](README.es.md)

--- a/docs/adr/0003-mdx-content-vs-database.fr.md
+++ b/docs/adr/0003-mdx-content-vs-database.fr.md
@@ -1,0 +1,39 @@
+**Langues :** [English](0003-mdx-content-vs-database.md) · **Français** · [Kreyòl Ayisyen](0003-mdx-content-vs-database.ht.md) · [Español](0003-mdx-content-vs-database.es.md)
+
+[← Index des ADR](README.fr.md) · [Architecture](../ARCHITECTURE.fr.md)
+
+---
+
+# 0003 — Contenu de prose en MDX, pas en base
+
+- **Statut :** Accepté
+- **Date :** 2025-09-01
+- **Décideurs :** mainteneurs du projet
+
+## Contexte
+
+Le portail a besoin de prose en quatre langues : descriptions de services, actualités, pages légales. Trois options : tout en base, CMS headless tiers (Sanity, Contentful…), fichiers MDX dans le dépôt.
+
+Contraintes : édition par des traducteurs non-développeurs ; historique auditable ; pas d'abonnement SaaS récurrent qui bloque les communes à faibles ressources ; relecture type code (PR + diff).
+
+## Décision
+
+Prose dans `src/content/**/*.mdx`. Étiquettes courtes dans `messages/{locale}.json`. Champs dynamiques admin en colonnes JSONB.
+
+Les traducteurs éditent via GitHub web ; voir [Guide de contenu](../CONTENT_GUIDE.fr.md).
+
+## Conséquences
+
+**Positives :** gratuit ; historique Git complet ; PR pour le contenu comme pour le code ; repli locale = simple lecture fichier ; contenu portable.
+
+**Négatives :** changements en prod nécessitent redéploiement (Vercel le rend instantané) ; les traducteurs doivent apprendre GitHub (~30 min) ; éditions en masse via PR multiples ou imports CSV.
+
+**Neutres :** future UI admin pour éditer du MDX en navigateur prévue ; stockage identique.
+
+## Alternatives examinées
+
+- **Tout en base** : traduction difficile sans CMS ; pas d'historique.
+- **CMS headless** : coût récurrent ; verrou éditeur ; nouveau login pour les éditeurs.
+- **Decap CMS** (Git, open-source) : ajout futur qui *complète* MDX plutôt que de le remplacer.
+
+[↑ Retour en haut](#0003--contenu-de-prose-en-mdx-pas-en-base) · [← Précédent : 0002](0002-uuid-primary-keys.fr.md) · [Index des ADR](README.fr.md)

--- a/docs/adr/0003-mdx-content-vs-database.ht.md
+++ b/docs/adr/0003-mdx-content-vs-database.ht.md
@@ -1,0 +1,39 @@
+**Lang yo:** [English](0003-mdx-content-vs-database.md) · [Français](0003-mdx-content-vs-database.fr.md) · **Kreyòl Ayisyen** · [Español](0003-mdx-content-vs-database.es.md)
+
+[← Endèks ADR](README.ht.md) · [Achitekti](../ARCHITECTURE.ht.md)
+
+---
+
+# 0003 — Kontni prose nan MDX, pa nan baz done
+
+- **Estati:** Aksepte
+- **Dat:** 2025-09-01
+- **Desidè:** mainteneurs pwojè a
+
+## Kontèks
+
+Pòtal la bezwen prose nan kat lang: deskripsyon sèvis, atik nouvèl, paj legal. Twa opsyon: tout nan baz, CMS headless tyès pati (Sanity, Contentful…), fichye MDX nan depo.
+
+Kontrent: tradiksyon pa moun ki pa devlopè; istwa odit; pa gen abònman SaaS k ap bloke komin ki gen ti resous; revizyon menm jan ak kòd (PR + diff).
+
+## Desizyon
+
+Prose nan `src/content/**/*.mdx`. Etikèt kout nan `messages/{locale}.json`. Chan dinamik admin nan kolòn JSONB.
+
+Tradiktè edite atravè GitHub web; wè [Gid Kontni](../CONTENT_GUIDE.ht.md).
+
+## Konsekans
+
+**Pozitif:** gratis; istwa Git konplè; PR pou kontni menm jan ak kòd; sekou lokal = senp lekti fichye; kontni pòtatif.
+
+**Negatif:** chanjman an pwodiksyon mande redeplwaman (Vercel rann li enstantane); tradiktè dwe aprann GitHub (~30 min); edisyon an mas atravè PR miltip oswa enpòt CSV.
+
+**Nyout:** UI admin pou edite MDX nan navigatè prevwa; estokaj rete menm.
+
+## Altènativ konsidere
+
+- **Tout nan baz**: tradiksyon difisil san CMS; pa gen istwa.
+- **CMS headless**: pri rekiran; vèrou; nouvo login pou editè.
+- **Decap CMS** (Git, kòd louvri): ajou fiti ki *konplete* MDX olye ranplase.
+
+[↑ Retounen anwo](#0003--kontni-prose-nan-mdx-pa-nan-baz-done) · [← Anvan: 0002](0002-uuid-primary-keys.ht.md) · [Endèks ADR](README.ht.md)

--- a/docs/adr/0003-mdx-content-vs-database.md
+++ b/docs/adr/0003-mdx-content-vs-database.md
@@ -1,0 +1,60 @@
+<!--
+Languages: English (this file) | Français (0003-mdx-content-vs-database.fr.md) | Kreyòl (0003-mdx-content-vs-database.ht.md) | Español (0003-mdx-content-vs-database.es.md)
+-->
+
+**Languages:** **English** · [Français](0003-mdx-content-vs-database.fr.md) · [Kreyòl Ayisyen](0003-mdx-content-vs-database.ht.md) · [Español](0003-mdx-content-vs-database.es.md)
+
+[← ADR index](README.md) · [Architecture](../ARCHITECTURE.md)
+
+---
+
+# 0003 — Prose content in MDX files, not the database
+
+- **Status:** Accepted
+- **Date:** 2025-09-01
+- **Deciders:** project maintainers
+
+## Context
+
+The portal needs prose content in four languages: service descriptions, news articles, legal pages. We had three options:
+
+1. Store all content in the database.
+2. Use a third-party headless CMS (Sanity, Contentful, Strapi, Decap).
+3. Store content as MDX files in the repository.
+
+Constraints:
+- Translators should be able to edit content without a developer.
+- We want a permanent, auditable history of every text change.
+- We must avoid recurring SaaS costs that block low-resource municipalities.
+- Content should be reviewable like code (PR + diff).
+
+## Decision
+
+Prose content lives in `src/content/**/*.mdx` files. UI labels (short strings) live in `messages/{locale}.json`. Dynamic, admin-edited multilingual fields use JSONB columns in the database.
+
+Translators edit MDX files via the GitHub web UI; see [Content Guide](../CONTENT_GUIDE.md).
+
+## Consequences
+
+**Positive:**
+- Free. No CMS subscription.
+- Full audit trail (Git history).
+- PRs review content alongside code.
+- Locale fallback to English is a one-line filesystem read.
+- Content is portable: an exported repo carries its content.
+
+**Negative:**
+- Content edits require redeploy in production (in dev, files are read at request time). Mitigated by Vercel's instant deploys.
+- Translators must use GitHub. Onboarding a non-technical translator takes ~30 minutes.
+- Bulk edits require either many PRs or coordinated CSV-style imports.
+
+**Neutral:**
+- A future admin UI to edit MDX in-browser is on the roadmap; the underlying storage stays the same.
+
+## Alternatives considered
+
+- **All-database content**: harder to translate without a CMS; no audit trail.
+- **Headless CMS**: recurring cost; vendor lock-in; another login for editors.
+- **Decap CMS** (open-source, Git-backed): considered as a future addition that *complements* MDX rather than replaces it.
+
+[↑ Back to top](#0003--prose-content-in-mdx-files-not-the-database) · [← Previous: 0002](0002-uuid-primary-keys.md) · [ADR index](README.md)

--- a/docs/adr/README.es.md
+++ b/docs/adr/README.es.md
@@ -1,0 +1,57 @@
+<!--
+Idiomas: English (README.md) | Français (README.fr.md) | Kreyòl (README.ht.md) | Español (este archivo)
+-->
+
+**Idiomas:** [English](README.md) · [Français](README.fr.md) · [Kreyòl Ayisyen](README.ht.md) · **Español**
+
+[← Índice de documentación](../README.es.md) · [README del proyecto](../../README.md) · [Glosario](../GLOSSARY.es.md)
+
+---
+
+# Registros de Decisiones de Arquitectura (ADR)
+
+Esta carpeta registra los *porqués* de las grandes decisiones técnicas de Haiti City Portal. Los ADR son documentos cortos e inmutables — una vez aceptados, describen historia. Si una decisión se revierte, escriba un nuevo ADR que reemplace al anterior.
+
+## Índice
+
+| # | Título | Estado |
+|---|---|---|
+| [0001](0001-multi-tenant-via-subdomain.es.md) | Multi-tenant vía subdominio + middleware | Aceptado |
+| [0002](0002-uuid-primary-keys.es.md) | Claves primarias UUID en todas las tablas | Aceptado |
+| [0003](0003-mdx-content-vs-database.es.md) | Contenido de prosa en MDX, no en la base | Aceptado |
+
+## Agregar un nuevo ADR
+
+1. Numere el archivo (`NNNN-título-corto.es.md`).
+2. Use la plantilla abajo.
+3. Envíe un PR. Discuta en el PR.
+4. Una vez fusionado: estado "Aceptado".
+5. Enlace el nuevo ADR desde este índice.
+
+## Plantilla
+
+```markdown
+# NNNN — Título
+
+- **Estado:** Propuesto | Aceptado | Reemplazado por ADR-XXXX | Obsoleto
+- **Fecha:** AAAA-MM-DD
+- **Decisores:** nombres o roles
+
+## Contexto
+
+¿Qué problema? ¿Qué restricciones?
+
+## Decisión
+
+¿Qué decidimos?
+
+## Consecuencias
+
+Positivas, negativas, neutras.
+
+## Alternativas consideradas
+
+¿Qué más miramos, y por qué lo rechazamos?
+```
+
+[↑ Volver arriba](#registros-de-decisiones-de-arquitectura-adr) · [← Índice de documentación](../README.es.md)

--- a/docs/adr/README.fr.md
+++ b/docs/adr/README.fr.md
@@ -1,0 +1,57 @@
+<!--
+Langues : English (README.md) | Français (ce fichier) | Kreyòl (README.ht.md) | Español (README.es.md)
+-->
+
+**Langues :** [English](README.md) · **Français** · [Kreyòl Ayisyen](README.ht.md) · [Español](README.es.md)
+
+[← Index de la documentation](../README.fr.md) · [README du projet](../../README.md) · [Glossaire](../GLOSSARY.fr.md)
+
+---
+
+# Décisions d'architecture (ADR)
+
+Ce dossier consigne les *pourquoi* des grandes décisions techniques de Haiti City Portal. Les ADR sont courts et immuables — une fois acceptés, ils décrivent l'histoire. Si une décision est inversée, écrivez un nouvel ADR qui supplante l'ancien.
+
+## Index
+
+| # | Titre | Statut |
+|---|---|---|
+| [0001](0001-multi-tenant-via-subdomain.fr.md) | Multi-tenant par sous-domaine + middleware | Accepté |
+| [0002](0002-uuid-primary-keys.fr.md) | Clés primaires UUID partout | Accepté |
+| [0003](0003-mdx-content-vs-database.fr.md) | Contenu de prose en MDX, pas en base | Accepté |
+
+## Ajouter un nouvel ADR
+
+1. Numérotez le fichier (`NNNN-titre-court.fr.md`).
+2. Utilisez le modèle ci-dessous.
+3. Soumettez une PR. Discussion dans la PR.
+4. Une fois fusionné : statut « Accepté ».
+5. Liez le nouvel ADR depuis cet index.
+
+## Modèle
+
+```markdown
+# NNNN — Titre
+
+- **Statut :** Proposé | Accepté | Supplanté par ADR-XXXX | Obsolète
+- **Date :** AAAA-MM-JJ
+- **Décideurs :** noms ou rôles
+
+## Contexte
+
+Quel problème ? Quelles contraintes ?
+
+## Décision
+
+Qu'avons-nous décidé ?
+
+## Conséquences
+
+Positives, négatives, neutres.
+
+## Alternatives examinées
+
+Quoi d'autre a été regardé, et pourquoi rejeté ?
+```
+
+[↑ Retour en haut](#décisions-darchitecture-adr) · [← Index de la documentation](../README.fr.md)

--- a/docs/adr/README.ht.md
+++ b/docs/adr/README.ht.md
@@ -1,0 +1,57 @@
+<!--
+Lang yo: English (README.md) | Français (README.fr.md) | Kreyòl (fichye sa a) | Español (README.es.md)
+-->
+
+**Lang yo:** [English](README.md) · [Français](README.fr.md) · **Kreyòl Ayisyen** · [Español](README.es.md)
+
+[← Endèks dokimantasyon](../README.ht.md) · [README pwojè a](../../README.md) · [Glosè](../GLOSSARY.ht.md)
+
+---
+
+# Dosye Desizyon Achitekti (ADR)
+
+Dosye sa a anrejistre *poukisa* dèyè desizyon teknik enpòtan nan Haiti City Portal. ADR yo se dokiman kout, imuab — yon fwa aksepte, yo dekri istwa. Si yon desizyon ranvèse, ekri yon nouvo ADR ki ranplase ansyen an.
+
+## Endèks
+
+| # | Tit | Estati |
+|---|---|---|
+| [0001](0001-multi-tenant-via-subdomain.ht.md) | Multi-tenant atravè soudomèn + middleware | Aksepte |
+| [0002](0002-uuid-primary-keys.ht.md) | Kle prensipal UUID toupatou | Aksepte |
+| [0003](0003-mdx-content-vs-database.ht.md) | Kontni prose nan MDX, pa nan baz done | Aksepte |
+
+## Ajoute yon nouvo ADR
+
+1. Nimewote fichye (`NNNN-tit-kout.ht.md`).
+2. Itilize modèl anba a.
+3. Soumèt yon PR. Diskite nan PR a.
+4. Yon fwa fizyone: estati « Aksepte ».
+5. Lye nouvo ADR la soti nan endèks sa a.
+
+## Modèl
+
+```markdown
+# NNNN — Tit
+
+- **Estati:** Pwopoze | Aksepte | Ranplase pa ADR-XXXX | Obsolet
+- **Dat:** AAAA-MM-JJ
+- **Desidè:** non oswa wòl
+
+## Kontèks
+
+Ki pwoblèm? Ki kontrent?
+
+## Desizyon
+
+Sa nou deside?
+
+## Konsekans
+
+Pozitif, negatif, nyout.
+
+## Altènativ konsidere
+
+Sa lòt nou te gade, epi poukisa rejte?
+```
+
+[↑ Retounen anwo](#dosye-desizyon-achitekti-adr) · [← Endèks dokimantasyon](../README.ht.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,57 @@
+<!--
+Languages: English (this file) | Français (README.fr.md) | Kreyòl (README.ht.md) | Español (README.es.md)
+-->
+
+**Languages:** **English** · [Français](README.fr.md) · [Kreyòl Ayisyen](README.ht.md) · [Español](README.es.md)
+
+[← Docs index](../README.md) · [Project README](../../README.md) · [Glossary](../GLOSSARY.md)
+
+---
+
+# Architecture Decision Records (ADRs)
+
+This folder records the *why* behind major technical decisions in Haiti City Portal. ADRs are short, immutable documents — once accepted, they describe history. If a decision is reversed, write a new ADR that supersedes the old one.
+
+## Index
+
+| # | Title | Status |
+|---|---|---|
+| [0001](0001-multi-tenant-via-subdomain.md) | Multi-tenancy via subdomain + middleware | Accepted |
+| [0002](0002-uuid-primary-keys.md) | UUID primary keys for every table | Accepted |
+| [0003](0003-mdx-content-vs-database.md) | Prose content in MDX files, not the database | Accepted |
+
+## How to add a new ADR
+
+1. Number the file sequentially (`NNNN-short-title.md`).
+2. Use the template below.
+3. Submit a Pull Request. Discuss in the PR.
+4. When merged, the status becomes "Accepted".
+5. Link to the new ADR from this index.
+
+## ADR template
+
+```markdown
+# NNNN — Title
+
+- **Status:** Proposed | Accepted | Superseded by ADR-XXXX | Deprecated
+- **Date:** YYYY-MM-DD
+- **Deciders:** names or roles
+
+## Context
+
+What is the problem? What constraints exist?
+
+## Decision
+
+What did we decide?
+
+## Consequences
+
+Positive, negative, and neutral results.
+
+## Alternatives considered
+
+What else did we look at, and why did we reject it?
+```
+
+[↑ Back to top](#architecture-decision-records-adrs) · [← Docs index](../README.md)


### PR DESCRIPTION
Add a comprehensive, role-based documentation hub designed for non-technical municipal staff, IT administrators, developers, translators, and contributors, available in all four supported locales (English, Francais, Kreyol Ayisyen, Espanol).

New documents (each in 4 languages):

- docs/README.md - audience-routed index

- docs/FOR_MUNICIPALITIES.md - plain-language guide for mayors and city staff

- docs/DEPLOYMENT.md - step-by-step production deployment

- docs/TENANT_ONBOARDING.md - add a new commune to a running deployment

- docs/ARCHITECTURE.md - one-page overview with Mermaid diagrams

- docs/ADMIN_MANUAL.md - day-to-day admin panel guide

- docs/CONTENT_GUIDE.md - translate or edit content via GitHub web UI (no coding)

- docs/GLOSSARY.md - definitions of every technical and Haitian civic term

- docs/adr/ - Architecture Decision Records (index + 3 initial ADRs)

- CODE_OF_CONDUCT.md - Contributor Covenant

Other changes:

- README.md - add prominent Documentation hub banner and Quick links by role; expand Further Documentation with grouped links

- .env.production.example - annotated production env template

- .gitignore - allow .env.production.example to be committed (mirrors .env.local.example exception)

## What does this PR do?
Added more granular documentation.